### PR TITLE
[model] invite/metadata: Remove the `revoked` field

### DIFF
--- a/model/src/invite/metadata.rs
+++ b/model/src/invite/metadata.rs
@@ -10,7 +10,6 @@ pub struct InviteMetadata {
     pub inviter: User,
     pub max_age: u64,
     pub max_uses: u64,
-    pub revoked: bool,
     pub temporary: bool,
     pub uses: u64,
 }


### PR DESCRIPTION
This field is removed cf. https://github.com/discordapp/discord-api-docs/commit/70390b75377098204ccda75e3a7240a1604c7639

Signed-off-by: Valdemar Erk <valdemar@erk.io>