### PR TITLE
[gateway] remove all unwraps, expects, panics

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -23,6 +23,7 @@ futures-util-preview = "0.3.0-alpha.19"
 log = "0.4"
 serde = { features = ["derive"], version = "1" }
 serde_json = "1"
+serde-value = "0.6"
 snafu = "0.5"
 tokio-executor = "0.2.0-alpha.6"
 tokio-net = "0.2.0-alpha.6"

--- a/gateway/src/cluster/mod.rs
+++ b/gateway/src/cluster/mod.rs
@@ -39,7 +39,7 @@
 ///         },
 ///         Event::MessageCreate(msg) if msg.content == "!latency" => {
 ///             if let Some(shard) = cluster.shard(shard_id).await {
-///                 let info = shard.info();
+///                 let info = shard.info().await;
 ///
 ///                 println!("Shard {}'s latency is {:?}", shard_id, info.latency());
 ///             }

--- a/gateway/src/event.rs
+++ b/gateway/src/event.rs
@@ -40,8 +40,8 @@ impl<'de> Visitor<'de> for GatewayEventVisitor {
     }
 
     fn visit_map<V>(self, mut map: V) -> Result<GatewayEvent, V::Error>
-        where
-            V: MapAccess<'de>,
+    where
+        V: MapAccess<'de>,
     {
         static VALID_OPCODES: &[&str] = &[
             "EVENT",
@@ -101,8 +101,7 @@ impl<'de> Visitor<'de> for GatewayEventVisitor {
                 let s = s.ok_or_else(|| DeError::missing_field("s"))?;
                 let t = t.ok_or_else(|| DeError::missing_field("t"))?;
 
-                let dispatch =
-                    DispatchEvent::try_from((t.as_ref(), d)).map_err(DeError::custom)?;
+                let dispatch = DispatchEvent::try_from((t.as_ref(), d)).map_err(DeError::custom)?;
 
                 GatewayEvent::Dispatch(s, Box::new(dispatch))
             },
@@ -129,9 +128,7 @@ impl<'de> Visitor<'de> for GatewayEventVisitor {
 
                 GatewayEvent::InvalidateSession(resumeable)
             },
-            OpCode::Identify => {
-                return Err(DeError::unknown_variant("Identify", VALID_OPCODES))
-            },
+            OpCode::Identify => return Err(DeError::unknown_variant("Identify", VALID_OPCODES)),
             OpCode::Reconnect => GatewayEvent::Reconnect,
             OpCode::RequestGuildMembers => {
                 return Err(DeError::unknown_variant(
@@ -139,9 +136,7 @@ impl<'de> Visitor<'de> for GatewayEventVisitor {
                     VALID_OPCODES,
                 ))
             },
-            OpCode::Resume => {
-                return Err(DeError::unknown_variant("Resume", VALID_OPCODES))
-            },
+            OpCode::Resume => return Err(DeError::unknown_variant("Resume", VALID_OPCODES)),
             OpCode::StatusUpdate => {
                 return Err(DeError::unknown_variant("StatusUpdate", VALID_OPCODES))
             },

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -3,7 +3,8 @@
     clippy::pedantic,
     future_incompatible,
     nonstandard_style,
-    rust_2018_idioms
+    rust_2018_idioms,
+    unsafe_code
 )]
 #![allow(clippy::module_name_repetitions)]
 

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -90,7 +90,7 @@ impl Shard {
     ///
     /// timer::delay_for(Duration::from_secs(1)).await;
     ///
-    /// let info = shard.info();
+    /// let info = shard.info().await;
     /// println!("Shard stage: {}", info.stage());
     /// # Ok(()) }
     /// ```
@@ -126,10 +126,10 @@ impl Shard {
 
     /// Returns information about the running of the shard, such as the current
     /// connection stage.
-    pub fn info(&self) -> Information {
+    pub async fn info(&self) -> Information {
         Information {
             id: self.config().shard()[0],
-            latency: self.0.session.heartbeats.latency(),
+            latency: self.0.session.heartbeats.latency().await,
             seq: self.0.session.seq(),
             stage: self.0.session.stage(),
         }

--- a/gateway/src/shard/session.rs
+++ b/gateway/src/shard/session.rs
@@ -91,7 +91,7 @@ impl Session {
 
     /// Returns the current shard stage.
     pub fn stage(&self) -> Stage {
-        Stage::try_from(self.stage.load(Ordering::Relaxed)).expect("invalid stage")
+        Stage::try_from(self.stage.load(Ordering::Relaxed)).unwrap_or_default()
     }
 
     /// Sets the stage.


### PR DESCRIPTION
Remove all of the unwraps, expects, and panics, using non-poisoning
alternatives like `futures::lock::Mutex` and opting to return errors
instead.

Signed-off-by: Zeyla Hellyer <zeyla@hellyer.dev>