### PR TITLE
[gateway/http] remove 'snafu' dependency

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -24,7 +24,6 @@ log = "0.4"
 serde = { features = ["derive"], version = "1" }
 serde_json = "1"
 serde-value = "0.6"
-snafu = "0.5"
 tokio-executor = "0.2.0-alpha.6"
 tokio-net = "0.2.0-alpha.6"
 tokio-timer = "0.3.0-alpha.6"

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -1,8 +1,7 @@
-use super::error::{Error, LargeThresholdInvalid, Result};
+use super::error::{Error, Result};
 use crate::shard::config::{Config as ShardConfig, ConfigBuilder as ShardConfigBuilder};
 use dawn_http::Client;
 use dawn_model::gateway::payload::update_status::UpdateStatusInfo;
-use snafu::ResultExt;
 use std::{
     convert::TryFrom,
     ops::{Bound, RangeBounds},
@@ -225,7 +224,9 @@ impl ConfigBuilder {
     pub fn large_threshold(&mut self, large_threshold: u64) -> Result<&mut Self> {
         self.1
             .large_threshold(large_threshold)
-            .context(LargeThresholdInvalid)?;
+            .map_err(|source| Error::LargeThresholdInvalid {
+                source,
+            })?;
 
         Ok(self)
     }

--- a/gateway/src/shard/connect.rs
+++ b/gateway/src/shard/connect.rs
@@ -1,20 +1,22 @@
-use super::error::{Connecting, ParsingUrl, Result};
+use super::error::{Error, Result};
 use log::debug;
-use snafu::ResultExt;
 use std::str::FromStr;
 use tokio_net::tcp::TcpStream;
 use tokio_tungstenite::{tungstenite::handshake::client::Request, MaybeTlsStream, WebSocketStream};
 use url::Url;
 
 pub async fn connect(url: &str) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>> {
-    let url = Url::from_str(url).with_context(|| ParsingUrl {
+    let url = Url::from_str(url).map_err(|source| Error::ParsingUrl {
+        source,
         url: url.to_owned(),
     })?;
 
     let request = Request::from(url);
     let (stream, _) = tokio_tungstenite::connect_async(request)
         .await
-        .context(Connecting)?;
+        .map_err(|source| Error::Connecting {
+            source,
+        })?;
 
     debug!("Shook hands with remote");
 

--- a/gateway/src/shard/stage.rs
+++ b/gateway/src/shard/stage.rs
@@ -12,16 +12,16 @@
 //! [`Shard`]: ../struct.Shard.html
 //! [`Stage`]: enum.Stage.html
 
-use snafu::Snafu;
 use std::{
     convert::TryFrom,
+    error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
 
 /// Reason for a failure while parsing a value into a [`Stage`].
 ///
 /// [`Stage`]: enum.Stage.html
-#[derive(Clone, Debug, Snafu)]
+#[derive(Clone, Debug)]
 pub enum StageConversionError {
     /// The integer isn't one that maps to a stage. For example, 7 might not map
     /// to a Stage variant.
@@ -30,6 +30,18 @@ pub enum StageConversionError {
         value: u8,
     },
 }
+
+impl Display for StageConversionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::InvalidInteger {
+                value,
+            } => write!(f, "The integer {} is invalid", value),
+        }
+    }
+}
+
+impl Error for StageConversionError {}
 
 /// The current connection stage of a [`Shard`].
 ///

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -22,7 +22,6 @@ log = "0.4"
 reqwest = { default-features = false, version = "0.10.0-alpha.1" }
 serde = "1"
 serde_json = "1"
-snafu = "0.5"
 tokio-executor = "0.2.0-alpha.6"
 url = "2"
 

--- a/http/src/ratelimiting/error.rs
+++ b/http/src/ratelimiting/error.rs
@@ -1,6 +1,7 @@
 use http::header::ToStrError;
-use snafu::Snafu;
 use std::{
+    error::Error as StdError,
+    fmt::{Display, Formatter, Result as FmtResult},
     num::{ParseFloatError, ParseIntError},
     result::Result as StdResult,
     str::ParseBoolError,
@@ -8,8 +9,7 @@ use std::{
 
 pub type RatelimitResult<T> = StdResult<T, RatelimitError>;
 
-#[derive(Debug, Snafu)]
-#[snafu(visibility(pub(crate)))]
+#[derive(Debug)]
 pub enum RatelimitError {
     NoHeaders,
     HeaderMissing {
@@ -35,4 +35,70 @@ pub enum RatelimitError {
         source: ParseIntError,
         text: String,
     },
+}
+
+impl Display for RatelimitError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::NoHeaders => f.write_str("No headers are present"),
+            Self::HeaderMissing {
+                name,
+            } => write!(f, "At least one header, {:?}, is missing", name),
+            Self::HeaderNotUtf8 {
+                name,
+                value,
+                ..
+            } => write!(f, "The header {:?} has invalid UTF-8: {:?}", name, value),
+            Self::ParsingBoolText {
+                name,
+                text,
+                ..
+            } => write!(
+                f,
+                "The header {:?} should be a bool but isn't: {:?}",
+                name, text
+            ),
+            Self::ParsingFloatText {
+                name,
+                text,
+                ..
+            } => write!(
+                f,
+                "The header {:?} should be a float but isn't: {:?}",
+                name, text
+            ),
+            Self::ParsingIntText {
+                name,
+                text,
+                ..
+            } => write!(
+                f,
+                "The header {:?} should be an integer but isn't: {:?}",
+                name, text
+            ),
+        }
+    }
+}
+
+impl StdError for RatelimitError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::HeaderNotUtf8 {
+                source, ..
+            } => Some(source),
+            Self::ParsingBoolText {
+                source, ..
+            } => Some(source),
+            Self::ParsingFloatText {
+                source, ..
+            } => Some(source),
+            Self::ParsingIntText {
+                source, ..
+            } => Some(source),
+            Self::NoHeaders
+            | Self::HeaderMissing {
+                ..
+            } => None,
+        }
+    }
 }

--- a/http/src/ratelimiting/headers.rs
+++ b/http/src/ratelimiting/headers.rs
@@ -1,14 +1,5 @@
-use super::error::{
-    HeaderMissing,
-    HeaderNotUtf8,
-    ParsingBoolText,
-    ParsingFloatText,
-    ParsingIntText,
-    RatelimitError,
-    RatelimitResult,
-};
+use super::error::{RatelimitError, RatelimitResult};
 use http::header::{HeaderMap, HeaderValue};
-use snafu::{OptionExt, ResultExt};
 use std::convert::TryFrom;
 
 #[derive(Clone, Debug)]
@@ -119,68 +110,89 @@ fn parse_map(map: &HeaderMap<HeaderValue>) -> RatelimitResult<RatelimitHeaders> 
 }
 
 fn header_bool(map: &HeaderMap<HeaderValue>, name: &'static str) -> RatelimitResult<bool> {
-    let value = map.get(name).context(HeaderMissing {
+    let value = map.get(name).ok_or(RatelimitError::HeaderMissing {
         name,
     })?;
 
-    let text = value.to_str().with_context(|| HeaderNotUtf8 {
-        name,
-        value: value.as_bytes().to_owned(),
-    })?;
+    let text = value
+        .to_str()
+        .map_err(|source| RatelimitError::HeaderNotUtf8 {
+            name,
+            source,
+            value: value.as_bytes().to_owned(),
+        })?;
 
-    let end = text.parse().with_context(|| ParsingBoolText {
-        name,
-        text,
-    })?;
+    let end = text
+        .parse()
+        .map_err(|source| RatelimitError::ParsingBoolText {
+            name,
+            source,
+            text: text.to_owned(),
+        })?;
 
     Ok(end)
 }
 
 fn header_float(map: &HeaderMap<HeaderValue>, name: &'static str) -> RatelimitResult<f64> {
-    let value = map.get(name).context(HeaderMissing {
+    let value = map.get(name).ok_or(RatelimitError::HeaderMissing {
         name,
     })?;
 
-    let text = value.to_str().with_context(|| HeaderNotUtf8 {
-        name,
-        value: value.as_bytes().to_owned(),
-    })?;
+    let text = value
+        .to_str()
+        .map_err(|source| RatelimitError::HeaderNotUtf8 {
+            name,
+            source,
+            value: value.as_bytes().to_owned(),
+        })?;
 
-    let end = text.parse().with_context(|| ParsingFloatText {
-        name,
-        text,
-    })?;
+    let end = text
+        .parse()
+        .map_err(|source| RatelimitError::ParsingFloatText {
+            name,
+            source,
+            text: text.to_owned(),
+        })?;
 
     Ok(end)
 }
 
 fn header_int(map: &HeaderMap<HeaderValue>, name: &'static str) -> RatelimitResult<u64> {
-    let value = map.get(name).context(HeaderMissing {
+    let value = map.get(name).ok_or(RatelimitError::HeaderMissing {
         name,
     })?;
 
-    let text = value.to_str().with_context(|| HeaderNotUtf8 {
-        name,
-        value: value.as_bytes().to_owned(),
-    })?;
+    let text = value
+        .to_str()
+        .map_err(|source| RatelimitError::HeaderNotUtf8 {
+            name,
+            source,
+            value: value.as_bytes().to_owned(),
+        })?;
 
-    let end = text.parse().with_context(|| ParsingIntText {
-        name,
-        text,
-    })?;
+    let end = text
+        .parse()
+        .map_err(|source| RatelimitError::ParsingIntText {
+            name,
+            source,
+            text: text.to_owned(),
+        })?;
 
     Ok(end)
 }
 
 fn header_str<'a>(map: &'a HeaderMap<HeaderValue>, name: &'static str) -> RatelimitResult<&'a str> {
-    let value = map.get(name).context(HeaderMissing {
+    let value = map.get(name).ok_or(RatelimitError::HeaderMissing {
         name,
     })?;
 
-    let text = value.to_str().with_context(|| HeaderNotUtf8 {
-        name,
-        value: value.as_bytes().to_owned(),
-    })?;
+    let text = value
+        .to_str()
+        .map_err(|source| RatelimitError::HeaderNotUtf8 {
+            name,
+            source,
+            value: value.as_bytes().to_owned(),
+        })?;
 
     Ok(text)
 }


### PR DESCRIPTION
Remove snafu as a dependency, opting to instead use `Result::map_err`
and `Option::ok_or` directly and implementing `std::error::Error` and
`std::fmt::Display` on error types directly.

This cuts 7 dependencies from the total tree.

Signed-off-by: Zeyla Hellyer <zeyla@hellyer.dev>