### PR TITLE
[http] remove 'http' and 'url' dependencies

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -16,14 +16,12 @@ version = "0.1.0"
 futures-channel-preview = "0.3.0-alpha.19"
 futures-util-preview = "0.3.0-alpha.19"
 futures-timer = "0.5"
-http = "0.1"
 dawn-model = { path = "../model" }
 log = "0.4"
 reqwest = { default-features = false, version = "0.10.0-alpha.1" }
 serde = "1"
 serde_json = "1"
 tokio-executor = "0.2.0-alpha.6"
-url = "2"
 
 [dev-dependencies]
 tokio = "0.2.0-alpha.6"

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -23,7 +23,6 @@ use reqwest::{
     ClientBuilder as ReqwestClientBuilder,
     Response,
     StatusCode,
-    Url,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::json;
@@ -31,7 +30,6 @@ use std::{
     convert::TryFrom,
     fmt::{Debug, Formatter, Result as FmtResult},
     ops::{Deref, DerefMut},
-    str::FromStr,
     sync::Arc,
 };
 
@@ -977,16 +975,9 @@ impl Client {
 
         let protocol = if self.state.use_http { "http" } else { "https" };
         let url = format!("{}://discordapp.com/api/v6/{}", protocol, path);
-
-        let url = Url::from_str(&url).map_err(|source| Error::InvalidUrl {
-            method: method.clone(),
-            path: (*path).to_owned(),
-            source,
-        })?;
-
         debug!("URL: {:?}", url);
 
-        let mut builder = self.state.http.request(method.clone(), url);
+        let mut builder = self.state.http.request(method.clone(), &url);
 
         if let Some(bytes) = body {
             builder = builder.body(Body::from(bytes));

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -1,14 +1,12 @@
 use crate::ratelimiting::RatelimitError;
 use futures_channel::oneshot::Canceled;
-use http::{header::InvalidHeaderValue, method::Method, Error as HttpError};
-use reqwest::{Error as ReqwestError, Response as ReqwestResponse};
+use reqwest::{header::InvalidHeaderValue, Error as ReqwestError, Response as ReqwestResponse};
 use serde_json::Error as JsonError;
 use std::{
     error::Error as StdError,
     fmt::{Display, Error as FmtError, Formatter, Result as FmtResult},
     result::Result as StdResult,
 };
-use url::ParseError;
 
 pub type Result<T> = StdResult<T, Error>;
 
@@ -55,11 +53,6 @@ pub enum Error {
     Formatting {
         source: FmtError,
     },
-    InvalidUrl {
-        method: Method,
-        path: String,
-        source: ParseError,
-    },
     Json {
         source: JsonError,
     },
@@ -69,10 +62,6 @@ pub enum Error {
     },
     Ratelimiting {
         source: RatelimitError,
-    },
-    RequestBuilding {
-        path: String,
-        source: HttpError,
     },
     RequestCanceled {
         source: Canceled,
@@ -116,9 +105,6 @@ impl Display for Error {
             Self::Formatting {
                 ..
             } => f.write_str("Formatting a string failed"),
-            Self::InvalidUrl {
-                path, ..
-            } => write!(f, "Path {} is invalid", path),
             Self::Json {
                 ..
             } => f.write_str("Given value couldn't be serialized"),
@@ -128,9 +114,6 @@ impl Display for Error {
             Self::Ratelimiting {
                 ..
             } => f.write_str("Ratelimiting failure"),
-            Self::RequestBuilding {
-                ..
-            } => f.write_str("Request couldn't be built"),
             Self::RequestCanceled {
                 ..
             } => f.write_str("Request was canceled either before or while being sent"),
@@ -153,9 +136,6 @@ impl StdError for Error {
             Self::Formatting {
                 source,
             } => Some(source),
-            Self::InvalidUrl {
-                source, ..
-            } => Some(source),
             Self::Json {
                 source,
             }
@@ -164,9 +144,6 @@ impl StdError for Error {
             } => Some(source),
             Self::Ratelimiting {
                 source,
-            } => Some(source),
-            Self::RequestBuilding {
-                source, ..
             } => Some(source),
             Self::RequestCanceled {
                 source,

--- a/http/src/ratelimiting/error.rs
+++ b/http/src/ratelimiting/error.rs
@@ -1,4 +1,4 @@
-use http::header::ToStrError;
+use reqwest::header::ToStrError;
 use std::{
     error::Error as StdError,
     fmt::{Display, Formatter, Result as FmtResult},

--- a/http/src/ratelimiting/headers.rs
+++ b/http/src/ratelimiting/headers.rs
@@ -1,5 +1,5 @@
 use super::error::{RatelimitError, RatelimitResult};
-use http::header::{HeaderMap, HeaderValue};
+use reqwest::header::{HeaderMap, HeaderValue};
 use std::convert::TryFrom;
 
 #[derive(Clone, Debug)]

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -98,9 +98,9 @@ use crate::{
     error::Result,
     routing::{Path, Route},
 };
-use http::{
+use reqwest::{
     header::{HeaderMap, HeaderValue},
-    method::Method,
+    Method,
 };
 use std::{borrow::Cow, future::Future, pin::Pin};
 

--- a/http/src/request/prelude.rs
+++ b/http/src/request/prelude.rs
@@ -1,6 +1,6 @@
 pub(super) use super::{Pending, Request};
 pub use crate::{client::Client, error::Result, routing::Route};
-pub use http::Method;
+pub use reqwest::Method;
 pub use serde::{Deserialize, Serialize};
 pub use std::{
     future::Future,

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -1,4 +1,4 @@
-use http::Method;
+use reqwest::Method;
 use std::{
     borrow::Cow,
     convert::TryFrom,
@@ -1217,7 +1217,7 @@ impl Route {
 #[cfg(test)]
 mod tests {
     use super::{Path, PathParseError};
-    use http::Method;
+    use reqwest::Method;
     use std::{convert::TryFrom, error::Error, str::FromStr};
 
     #[test]


### PR DESCRIPTION
Remove the 'http' and 'url' dependencies, because reqwest re-exports
both of these crates' types that we need.
    
Although this doesn't reduce our dependency tree (reqwest depends on
them), it does cut back the surface of our direct dependencies.

Blocks on #15.
    
Signed-off-by: Zeyla Hellyer <zeyla@hellyer.dev>