### PR TITLE
[model] fix some incorrect model definitions

### DIFF
--- a/model/src/channel/embed/mod.rs
+++ b/model/src/channel/embed/mod.rs
@@ -23,7 +23,7 @@ pub use self::{
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Embed {
     pub author: Option<EmbedAuthor>,
-    #[serde(default)]
+    #[cfg_attr(feature = "serde-support", serde(default))]
     pub color: u32,
     pub description: Option<String>,
     #[cfg_attr(feature = "serde-support", serde(default))]

--- a/model/src/channel/reaction_type.rs
+++ b/model/src/channel/reaction_type.rs
@@ -9,8 +9,42 @@ use crate::id::EmojiId;
 pub enum ReactionType {
     Custom {
         animated: bool,
-        id: EmojiId,
+        // Although counter-intuitive, these *CAN* be not-present.
+        id: Option<EmojiId>,
         name: Option<String>,
     },
     Unicode(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReactionType;
+    use serde_test::Token;
+
+    #[test]
+    fn test_custom_null_id() {
+        let kind = ReactionType::Custom {
+            animated: false,
+            id: None,
+            name: Some("foo".to_owned()),
+        };
+
+        serde_test::assert_de_tokens(
+            &kind,
+            &[
+                Token::Struct {
+                    name: "ReactionType",
+                    len: 3,
+                },
+                Token::Str("animated"),
+                Token::Bool(false),
+                Token::Str("id"),
+                Token::None,
+                Token::Str("name"),
+                Token::Some,
+                Token::Str("foo"),
+                Token::StructEnd,
+            ],
+        );
+    }
 }

--- a/model/src/gateway/payload/voice_state_update.rs
+++ b/model/src/gateway/payload/voice_state_update.rs
@@ -1,11 +1,149 @@
-use crate::{id::GuildId, voice::VoiceState};
+use crate::voice::VoiceState;
 
 #[cfg_attr(
     feature = "serde-support",
     derive(serde::Deserialize, serde::Serialize)
 )]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct VoiceStateUpdate {
-    pub guild_id: Option<GuildId>,
-    pub voice_state: VoiceState,
+pub struct VoiceStateUpdate(VoiceState);
+
+#[cfg(test)]
+mod tests {
+    use super::{VoiceState, VoiceStateUpdate};
+    use crate::{
+        guild::Member,
+        id::{GuildId, RoleId, UserId},
+        user::User,
+    };
+    use serde_test::Token;
+
+    #[test]
+    fn test_voice_state_update() {
+        let update = VoiceStateUpdate(VoiceState {
+            channel_id: None,
+            deaf: false,
+            guild_id: Some(GuildId(1)),
+            member: Some(Member {
+                deaf: false,
+                guild_id: None,
+                hoisted_role: Some(RoleId(4)),
+                joined_at: None,
+                mute: false,
+                nick: None,
+                premium_since: None,
+                roles: vec![RoleId(4)],
+                user: User {
+                    id: UserId(1),
+                    avatar: None,
+                    bot: false,
+                    discriminator: "0909".to_string(),
+                    name: "foo".to_string(),
+                },
+            }),
+            mute: false,
+            self_deaf: false,
+            self_mute: false,
+            self_stream: false,
+            session_id: "a".to_owned(),
+            suppress: false,
+            token: None,
+            user_id: UserId(1),
+        });
+
+        serde_test::assert_tokens(
+            &update,
+            &[
+                Token::NewtypeStruct {
+                    name: "VoiceStateUpdate",
+                },
+                Token::Struct {
+                    name: "VoiceState",
+                    len: 12,
+                },
+                Token::Str("channel_id"),
+                Token::None,
+                Token::Str("deaf"),
+                Token::Bool(false),
+                Token::Str("guild_id"),
+                Token::Some,
+                Token::NewtypeStruct {
+                    name: "GuildId",
+                },
+                Token::Str("1"),
+                Token::Str("member"),
+                Token::Some,
+                Token::Struct {
+                    name: "Member",
+                    len: 9,
+                },
+                Token::Str("deaf"),
+                Token::Bool(false),
+                Token::Str("guild_id"),
+                Token::None,
+                Token::Str("hoisted_role"),
+                Token::Some,
+                Token::NewtypeStruct {
+                    name: "RoleId",
+                },
+                Token::Str("4"),
+                Token::Str("joined_at"),
+                Token::None,
+                Token::Str("mute"),
+                Token::Bool(false),
+                Token::Str("nick"),
+                Token::None,
+                Token::Str("premium_since"),
+                Token::None,
+                Token::Str("roles"),
+                Token::Seq {
+                    len: Some(1),
+                },
+                Token::NewtypeStruct {
+                    name: "RoleId",
+                },
+                Token::Str("4"),
+                Token::SeqEnd,
+                Token::Str("user"),
+                Token::Struct {
+                    name: "User",
+                    len: 5,
+                },
+                Token::Str("id"),
+                Token::NewtypeStruct {
+                    name: "UserId",
+                },
+                Token::Str("1"),
+                Token::Str("avatar"),
+                Token::None,
+                Token::Str("bot"),
+                Token::Bool(false),
+                Token::Str("discriminator"),
+                Token::Str("0909"),
+                Token::Str("username"),
+                Token::Str("foo"),
+                Token::StructEnd,
+                Token::StructEnd,
+                Token::Str("mute"),
+                Token::Bool(false),
+                Token::Str("self_deaf"),
+                Token::Bool(false),
+                Token::Str("self_mute"),
+                Token::Bool(false),
+                Token::Str("self_stream"),
+                Token::Bool(false),
+                Token::Str("session_id"),
+                Token::Str("a"),
+                Token::Str("suppress"),
+                Token::Bool(false),
+                Token::Str("token"),
+                Token::None,
+                Token::Str("user_id"),
+                Token::NewtypeStruct {
+                    name: "UserId",
+                },
+                Token::Str("1"),
+                Token::StructEnd,
+            ],
+        );
+    }
 }

--- a/model/src/gateway/presence/activity.rs
+++ b/model/src/gateway/presence/activity.rs
@@ -18,8 +18,12 @@ use crate::{
 pub struct Activity {
     pub application_id: Option<ApplicationId>,
     pub assets: Option<ActivityAssets>,
+    // Introduced with custom statuses.
+    pub created_at: Option<u64>,
     pub details: Option<String>,
     pub flags: Option<ActivityFlags>,
+    // Introduced with custom statuses.
+    pub id: Option<String>,
     pub instance: Option<bool>,
     #[cfg_attr(
         feature = "serde-support",
@@ -32,4 +36,9 @@ pub struct Activity {
     pub state: Option<String>,
     pub timestamps: Option<ActivityTimestamps>,
     pub url: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    // Custom activities is tested by the custom presence test.
 }

--- a/model/src/gateway/presence/activity_type.rs
+++ b/model/src/gateway/presence/activity_type.rs
@@ -9,10 +9,47 @@ pub enum ActivityType {
     Streaming = 1,
     Listening = 2,
     Watching = 3,
+    Custom = 4,
 }
 
 impl Default for ActivityType {
     fn default() -> Self {
         Self::Playing
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ActivityType;
+    use serde_test::Token;
+
+    #[test]
+    fn test_default() {
+        assert_eq!(ActivityType::Playing, ActivityType::default());
+    }
+
+    #[test]
+    fn test_activity_type_playing() {
+        serde_test::assert_tokens(&ActivityType::Playing, &[Token::U8(0)]);
+    }
+
+    #[test]
+    fn test_activity_type_streaming() {
+        serde_test::assert_tokens(&ActivityType::Streaming, &[Token::U8(1)]);
+    }
+
+    #[test]
+    fn test_activity_type_listening() {
+        serde_test::assert_tokens(&ActivityType::Listening, &[Token::U8(2)]);
+    }
+
+    #[test]
+    fn test_activity_type_watching() {
+        serde_test::assert_tokens(&ActivityType::Watching, &[Token::U8(3)]);
+    }
+
+    #[test]
+    fn test_activity_type_custom() {
+        serde_test::assert_tokens(&ActivityType::Custom, &[Token::U8(4)]);
     }
 }

--- a/model/src/gateway/presence/client_status.rs
+++ b/model/src/gateway/presence/client_status.rs
@@ -10,3 +10,40 @@ pub struct ClientStatus {
     pub mobile: Option<Status>,
     pub web: Option<Status>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{ClientStatus, Status};
+    use serde_test::Token;
+
+    #[test]
+    fn test_mobile_online() {
+        let status = ClientStatus {
+            desktop: None,
+            mobile: Some(Status::Online),
+            web: None,
+        };
+
+        serde_test::assert_tokens(
+            &status,
+            &[
+                Token::Struct {
+                    name: "ClientStatus",
+                    len: 3,
+                },
+                Token::Str("desktop"),
+                Token::None,
+                Token::Str("mobile"),
+                Token::Some,
+                Token::Enum {
+                    name: "Status",
+                },
+                Token::Str("online"),
+                Token::Unit,
+                Token::Str("web"),
+                Token::None,
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/model/src/gateway/presence/mod.rs
+++ b/model/src/gateway/presence/mod.rs
@@ -69,3 +69,124 @@ mod serde_support {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Activity, ActivityType, ClientStatus, Presence, Status, UserOrId};
+    use crate::id::UserId;
+    use serde_test::Token;
+
+    #[test]
+    fn test_custom() {
+        let activity = Activity {
+            application_id: None,
+            assets: None,
+            created_at: Some(1571048061237),
+            details: None,
+            flags: None,
+            id: Some("aaaaaaaaaaaaaaaa".to_owned()),
+            instance: None,
+            kind: ActivityType::Custom,
+            name: "foo".to_owned(),
+            party: None,
+            secrets: None,
+            state: None,
+            timestamps: None,
+            url: None,
+        };
+        let presence = Presence {
+            activities: vec![activity.clone()],
+            client_status: ClientStatus {
+                desktop: Some(Status::Online),
+                mobile: None,
+                web: None,
+            },
+            game: Some(activity),
+            guild_id: None,
+            nick: None,
+            status: Status::Online,
+            user: UserOrId::UserId {
+                id: UserId(1),
+            },
+        };
+
+        serde_test::assert_de_tokens(
+            &presence,
+            &[
+                Token::Struct {
+                    name: "Presence",
+                    len: 4,
+                },
+                Token::Str("user"),
+                Token::Struct {
+                    name: "UserOrId",
+                    len: 1,
+                },
+                Token::Str("id"),
+                Token::Str("1"),
+                Token::StructEnd,
+                Token::Str("status"),
+                Token::Enum {
+                    name: "Status",
+                },
+                Token::Str("online"),
+                Token::Unit,
+                Token::Str("game"),
+                Token::Some,
+                Token::Struct {
+                    name: "Activity",
+                    len: 4,
+                },
+                Token::Str("type"),
+                Token::U8(4),
+                Token::Str("name"),
+                Token::Str("foo"),
+                Token::Str("id"),
+                Token::Some,
+                Token::Str("aaaaaaaaaaaaaaaa"),
+                Token::Str("created_at"),
+                Token::Some,
+                Token::U64(1571048061237),
+                Token::StructEnd,
+                Token::Str("client_status"),
+                Token::Struct {
+                    name: "ClientStatus",
+                    len: 3,
+                },
+                Token::Str("desktop"),
+                Token::Some,
+                Token::Enum {
+                    name: "Status",
+                },
+                Token::Str("online"),
+                Token::Unit,
+                Token::Str("mobile"),
+                Token::None,
+                Token::Str("web"),
+                Token::None,
+                Token::StructEnd,
+                Token::Str("activities"),
+                Token::Seq {
+                    len: Some(1),
+                },
+                Token::Struct {
+                    name: "Activity",
+                    len: 4,
+                },
+                Token::Str("type"),
+                Token::U8(4),
+                Token::Str("name"),
+                Token::Str("foo"),
+                Token::Str("id"),
+                Token::Some,
+                Token::Str("aaaaaaaaaaaaaaaa"),
+                Token::Str("created_at"),
+                Token::Some,
+                Token::U64(1571048061237),
+                Token::StructEnd,
+                Token::SeqEnd,
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/model/src/guild/member.rs
+++ b/model/src/guild/member.rs
@@ -11,6 +11,7 @@ use crate::{
 pub struct Member {
     pub deaf: bool,
     pub guild_id: Option<GuildId>,
+    pub hoisted_role: Option<RoleId>,
     pub joined_at: Option<String>,
     pub mute: bool,
     pub nick: Option<String>,


### PR DESCRIPTION
Fix some of the model definitions and fix compilation without the serde
feature.

- in `channel::embed::Embed`, gate the `color` serde attribute behind
the `serde-support` feature
- make `channel::ReactionType::Custom::id` optional
- make `gateway::payload::VoiceStateUpdate` a newtype around
`voice::VoiceState`
- add `gateway::presence::Activity::created_at` and `id` for custom
presences
- add `gateway::presence::ActivityType::Custom` (variant 4)
- add `guild::Member::hoisted_role`

Additionally, add tests for all of these using payloads that triggered
deserialization fails. These tests use `serde_test` for
implementation-agnostic accuracy.

Signed-off-by: Zeyla Hellyer <zeyla@hellyer.dev>