### PR TITLE
[model] make gateway::payload::memberadd a newtype

### DIFF
--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -255,14 +255,20 @@ impl UpdateCache<MemberAdd> for InMemoryCache {
             return Ok(());
         }
 
-        self.cache_member(event.guild_id, event.member.clone())
+        // This will always be present on members from the gateway.
+        let guild_id = match event.guild_id {
+            Some(guild_id) => guild_id,
+            None => return Ok(()),
+        };
+
+        self.cache_member(guild_id, event.0.clone())
             .await;
 
         let mut guild = self.0.guild_members.lock().await;
         guild
-            .entry(event.guild_id)
+            .entry(guild_id)
             .or_default()
-            .insert(event.member.user.id);
+            .insert(event.0.user.id);
 
         Ok(())
     }

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -261,14 +261,10 @@ impl UpdateCache<MemberAdd> for InMemoryCache {
             None => return Ok(()),
         };
 
-        self.cache_member(guild_id, event.0.clone())
-            .await;
+        self.cache_member(guild_id, event.0.clone()).await;
 
         let mut guild = self.0.guild_members.lock().await;
-        guild
-            .entry(guild_id)
-            .or_default()
-            .insert(event.0.user.id);
+        guild.entry(guild_id).or_default().insert(event.0.user.id);
 
         Ok(())
     }

--- a/model/src/gateway/payload/member_add.rs
+++ b/model/src/gateway/payload/member_add.rs
@@ -1,4 +1,5 @@
 use crate::guild::Member;
+use std::ops::{Deref, DerefMut};
 
 #[cfg_attr(
     feature = "serde-support",
@@ -6,6 +7,20 @@ use crate::guild::Member;
 )]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct MemberAdd(pub Member);
+
+impl Deref for MemberAdd {
+    type Target = Member;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for MemberAdd {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/model/src/gateway/payload/member_add.rs
+++ b/model/src/gateway/payload/member_add.rs
@@ -1,11 +1,95 @@
-use crate::{guild::Member, id::GuildId};
+use crate::guild::Member;
 
 #[cfg_attr(
     feature = "serde-support",
     derive(serde::Deserialize, serde::Serialize)
 )]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct MemberAdd {
-    pub guild_id: GuildId,
-    pub member: Member,
+pub struct MemberAdd(pub Member);
+
+#[cfg(test)]
+mod tests {
+    use super::{Member, MemberAdd};
+    use crate::{
+        id::{GuildId, UserId},
+        user::User,
+    };
+    use serde_test::Token;
+
+    #[test]
+    fn test_member_add() {
+        let member_add = MemberAdd(Member {
+            deaf: false,
+            guild_id: Some(GuildId(1)),
+            hoisted_role: None,
+            joined_at: None,
+            mute: false,
+            nick: None,
+            premium_since: None,
+            roles: vec![],
+            user: User {
+                id: UserId(2),
+                avatar: None,
+                bot: false,
+                discriminator: "0987".to_string(),
+                name: "ab".to_string(),
+            },
+        });
+
+        serde_test::assert_tokens(
+            &member_add,
+            &[
+                Token::NewtypeStruct {
+                    name: "MemberAdd",
+                },
+                Token::Struct {
+                    name: "Member",
+                    len: 9,
+                },
+                Token::Str("deaf"),
+                Token::Bool(false),
+                Token::Str("guild_id"),
+                Token::Some,
+                Token::NewtypeStruct {
+                    name: "GuildId",
+                },
+                Token::Str("1"),
+                Token::Str("hoisted_role"),
+                Token::None,
+                Token::Str("joined_at"),
+                Token::None,
+                Token::Str("mute"),
+                Token::Bool(false),
+                Token::Str("nick"),
+                Token::None,
+                Token::Str("premium_since"),
+                Token::None,
+                Token::Str("roles"),
+                Token::Seq {
+                    len: Some(0),
+                },
+                Token::SeqEnd,
+                Token::Str("user"),
+                Token::Struct {
+                    name: "User",
+                    len: 5,
+                },
+                Token::Str("id"),
+                Token::NewtypeStruct {
+                    name: "UserId",
+                },
+                Token::Str("2"),
+                Token::Str("avatar"),
+                Token::None,
+                Token::Str("bot"),
+                Token::Bool(false),
+                Token::Str("discriminator"),
+                Token::Str("0987"),
+                Token::Str("username"),
+                Token::Str("ab"),
+                Token::StructEnd,
+                Token::StructEnd,
+            ],
+        );
+    }
 }


### PR DESCRIPTION
Make `gateway::payload::MemberAdd` a newtype around `guild::Member`,
because the payload includes no additional information.

A test case for this event has been added with one of the payloads that
failed deserialization.

Signed-off-by: Zeyla Hellyer <zeyla@hellyer.dev>