### PR TITLE
[cache] rework 'cache' and 'cacheupdate'

### DIFF
--- a/cache/base/Cargo.toml
+++ b/cache/base/Cargo.toml
@@ -5,9 +5,5 @@ name = "dawn-cache"
 version = "0.1.0"
 
 [dependencies]
-dawn-cache-inmemory = { optional = true, path = "../in-memory" }
+dawn-cache-inmemory = { path = "../in-memory" }
 dawn-cache-trait = { path = "../trait" }
-
-[features]
-default = ["in-memory"]
-in-memory = ["dawn-cache-inmemory"]

--- a/cache/base/src/lib.rs
+++ b/cache/base/src/lib.rs
@@ -1,4 +1,4 @@
-pub use dawn_cache_trait::{Cache, UpdateCache};
+pub extern crate dawn_cache_inmemory;
 
-#[cfg(feature = "dawn-cache-inmemory")]
-pub use dawn_cache_inmemory::InMemoryCache;
+pub use dawn_cache_inmemory::{InMemoryCache, InMemoryCacheError};
+pub use dawn_cache_trait::{Cache, UpdateCache};

--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -10,3 +10,7 @@ bitflags = "1"
 futures-util-preview = "0.3.0-alpha.18"
 dawn-cache-trait = { path = "../trait" }
 dawn-model = { default-features = false, path = "../../model" }
+
+[dev-dependencies]
+static_assertions = "1"
+tokio = "0.2.0-alpha.6"

--- a/cache/in-memory/src/config.rs
+++ b/cache/in-memory/src/config.rs
@@ -120,3 +120,64 @@ impl ConfigBuilder {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, ConfigBuilder, EventType};
+
+    #[test]
+    fn test_event_type_const_values() {
+        assert_eq!(1, EventType::BAN_ADD.bits());
+        assert_eq!(1 << 1, EventType::BAN_REMOVE.bits());
+        assert_eq!(1 << 2, EventType::CHANNEL_CREATE.bits());
+        assert_eq!(1 << 3, EventType::CHANNEL_DELETE.bits());
+        assert_eq!(1 << 4, EventType::CHANNEL_UPDATE.bits());
+        assert_eq!(1 << 5, EventType::GUILD_CREATE.bits());
+        assert_eq!(1 << 6, EventType::GUILD_DELETE.bits());
+        assert_eq!(1 << 7, EventType::GUILD_EMOJIS_UPDATE.bits());
+        assert_eq!(1 << 8, EventType::GUILD_INTEGRATIONS_UPDATE.bits());
+        assert_eq!(1 << 9, EventType::GUILD_UPDATE.bits());
+        assert_eq!(1 << 10, EventType::MEMBER_ADD.bits());
+        assert_eq!(1 << 11, EventType::MEMBER_CHUNK.bits());
+        assert_eq!(1 << 12, EventType::MEMBER_REMOVE.bits());
+        assert_eq!(1 << 13, EventType::MEMBER_UPDATE.bits());
+        assert_eq!(1 << 14, EventType::MESSAGE_CREATE.bits());
+        assert_eq!(1 << 15, EventType::MESSAGE_DELETE.bits());
+        assert_eq!(1 << 16, EventType::MESSAGE_DELETE_BULK.bits());
+        assert_eq!(1 << 17, EventType::MESSAGE_UPDATE.bits());
+        assert_eq!(1 << 18, EventType::PRESENCE_UPDATE.bits());
+        assert_eq!(1 << 19, EventType::REACTION_ADD.bits());
+        assert_eq!(1 << 20, EventType::REACTION_REMOVE.bits());
+        assert_eq!(1 << 21, EventType::REACTION_REMOVE_ALL.bits());
+        assert_eq!(1 << 22, EventType::READY.bits());
+        assert_eq!(1 << 23, EventType::ROLE_CREATE.bits());
+        assert_eq!(1 << 24, EventType::ROLE_DELETE.bits());
+        assert_eq!(1 << 25, EventType::ROLE_UPDATE.bits());
+        assert_eq!(1 << 26, EventType::TYPING_START.bits());
+        assert_eq!(1 << 27, EventType::UNAVAILABLE_GUILD.bits());
+        assert_eq!(1 << 28, EventType::UPDATE_VOICE_STATE.bits());
+        assert_eq!(1 << 29, EventType::USER_UPDATE.bits());
+        assert_eq!(1 << 30, EventType::VOICE_SERVER_UPDATE.bits());
+        assert_eq!(1 << 31, EventType::VOICE_STATE_UPDATE.bits());
+        assert_eq!(1 << 32, EventType::WEBHOOK_UPDATE.bits());
+    }
+
+    #[test]
+    fn test_defaults() {
+        let conf = Config {
+            event_types: EventType::all(),
+            message_cache_size: 100,
+        };
+        let default = Config::default();
+        assert_eq!(conf.event_types, default.event_types);
+        assert_eq!(conf.message_cache_size, default.message_cache_size);
+        let default = ConfigBuilder::default();
+        assert_eq!(conf.event_types, default.0.event_types);
+        assert_eq!(conf.message_cache_size, default.0.message_cache_size);
+    }
+
+    #[test]
+    fn test_config_fields() {
+        static_assertions::assert_fields!(Config: event_types, message_cache_size);
+    }
+}

--- a/cache/in-memory/src/model/emoji.rs
+++ b/cache/in-memory/src/model/emoji.rs
@@ -26,3 +26,52 @@ impl PartialEq<Emoji> for CachedEmoji {
             && self.roles == other.roles
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CachedEmoji;
+    use dawn_model::{guild::Emoji, id::EmojiId};
+    use std::fmt::Debug;
+
+    #[test]
+    fn test_eq_emoji() {
+        let emoji = Emoji {
+            id: EmojiId(123),
+            animated: true,
+            name: "foo".to_owned(),
+            managed: false,
+            require_colons: true,
+            roles: vec![],
+            user: None,
+        };
+        let cached = CachedEmoji {
+            id: EmojiId(123),
+            animated: true,
+            name: "foo".to_owned(),
+            managed: false,
+            require_colons: true,
+            roles: vec![],
+            user: None,
+        };
+
+        assert_eq!(cached, emoji);
+    }
+
+    #[test]
+    fn test_fields() {
+        static_assertions::assert_fields!(
+            CachedEmoji: id,
+            animated,
+            name,
+            managed,
+            require_colons,
+            roles,
+            user
+        );
+    }
+
+    #[test]
+    fn test_impls() {
+        static_assertions::assert_impl_all!(CachedEmoji: Clone, Debug, Eq, PartialEq);
+    }
+}

--- a/cache/in-memory/src/model/mod.rs
+++ b/cache/in-memory/src/model/mod.rs
@@ -15,3 +15,11 @@ pub use self::{
     presence::CachedPresence,
     voice_state::CachedVoiceState,
 };
+
+#[cfg(tests)]
+mod tests {
+    #[test]
+    fn test_reexports() {
+        use super::{CachedEmoji, CachedGuild, CachedMember, CachedPresence, CachedVoiceState};
+    }
+}

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -265,10 +265,7 @@ impl UpdateCache<InMemoryCache, InMemoryCacheError> for MemberAdd {
         cache.cache_member(guild_id, self.0.clone()).await;
 
         let mut guild = cache.0.guild_members.lock().await;
-        guild
-            .entry(guild_id)
-            .or_default()
-            .insert(self.0.user.id);
+        guild.entry(guild_id).or_default().insert(self.0.user.id);
 
         Ok(())
     }

--- a/cache/trait/Cargo.toml
+++ b/cache/trait/Cargo.toml
@@ -15,3 +15,6 @@ version = "0.1.0"
 [dependencies]
 async-trait = "0.1"
 dawn-model = { default-features = false, path = "../../model" }
+
+[dev-dependencies]
+static_assertions = "1"

--- a/cache/trait/src/lib.rs
+++ b/cache/trait/src/lib.rs
@@ -1,73 +1,27 @@
 use async_trait::async_trait;
-use dawn_model::id::{ChannelId, EmojiId, GuildId, MessageId, RoleId, UserId};
 use std::fmt::Debug;
 
+pub trait Cache: Debug + Send + Sync {}
+
 #[async_trait]
-pub trait Cache {
-    type Error: Debug;
-    type CurrentUser;
-    type Emoji;
-    type Group;
-    type Guild;
-    type GuildChannel;
-    type Member;
-    type Message;
-    type Presence;
-    type PrivateChannel;
-    type Role;
-    type User;
-    type VoiceState;
-
-    async fn guild_channel(
-        &self,
-        channel_id: ChannelId,
-    ) -> Result<Option<Self::GuildChannel>, Self::Error>;
-
-    async fn current_user(&self) -> Result<Option<Self::CurrentUser>, Self::Error>;
-
-    async fn emoji(&self, emoji_id: EmojiId) -> Result<Option<Self::Emoji>, Self::Error>;
-
-    async fn group(&self, channel_id: ChannelId) -> Result<Option<Self::Group>, Self::Error>;
-
-    async fn guild(&self, guild_id: GuildId) -> Result<Option<Self::Guild>, Self::Error>;
-
-    async fn member(
-        &self,
-        guild_id: GuildId,
-        user_id: UserId,
-    ) -> Result<Option<Self::Member>, Self::Error>;
-
-    async fn message(
-        &self,
-        channel_id: ChannelId,
-        message_id: MessageId,
-    ) -> Result<Option<Self::Message>, Self::Error>;
-
-    async fn presence(
-        &self,
-        guild_id: Option<GuildId>,
-        user_id: UserId,
-    ) -> Result<Option<Self::Presence>, Self::Error>;
-
-    async fn private_channel(
-        &self,
-        channel_id: ChannelId,
-    ) -> Result<Option<Self::PrivateChannel>, Self::Error>;
-
-    async fn role(&self, role_id: RoleId) -> Result<Option<Self::Role>, Self::Error>;
-
-    async fn user(&self, user_id: UserId) -> Result<Option<Self::User>, Self::Error>;
-
-    async fn voice_state(
-        &self,
-        channel_id: ChannelId,
-        user_id: UserId,
-    ) -> Result<Option<Self::VoiceState>, Self::Error>;
-
-    async fn clear(&self) -> Result<(), Self::Error>;
+pub trait UpdateCache<T: Cache, Err> {
+    async fn update(&self, item: &T) -> Result<(), Err>;
 }
 
-#[async_trait]
-pub trait UpdateCache<T>: Cache {
-    async fn update(&self, item: &T) -> Result<(), Self::Error>;
+#[cfg(test)]
+mod tests {
+    use super::{Cache, UpdateCache};
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
+
+    #[test]
+    fn test_cache_bounds() {
+        static_assertions::assert_obj_safe!(Cache);
+        assert_impl_all!(dyn Cache: Debug, Send, Sync);
+    }
+
+    #[test]
+    fn test_cache_update_bounds() {
+        static_assertions::assert_obj_safe!(UpdateCache<(), ()>);
+    }
 }


### PR DESCRIPTION
Rework the `dawn_cache_trait::Cache` and `dawn_cache_trait::CacheUpdate`
traits to allow cache implementation pre-dispatches.

That doesn't make sense, but I couldn't make a catchy tagline for it.
Basically, the previous implementation of `CacheUpdate` required
implementing `CacheUpdate<T>` on the cache implementation, where T is
each event type.

This causes problems when a cache implementation wants to expose a
method which accepts any type that it has an update implementation for.
At least, I couldn't figure out how to do it. I don't think the type
system allows for it, and if it does it's wildly complex.

By using this method we switch from the trait definition:

```rust
pub trait UpdateCache<T>: Cache {
    async fn update(&self, item: &T) -> Result<(), Self::Error>;
}
```

to:

```rust
pub trait UpdateCache<T: Cache, Err> {
    async fn update(&self, item: &T) -> Result<(), Err>;
}
```

Additionally, we remove all of the methods from `Cache`. This allows
caches to only expose methods that they want for what they actually
cache. A cache for audio bots may only cache things like voice states,
but not guilds, roles, members, or anything else.

Additionally, re-export `dawn_cache_inmemory::InMemoryCacheError` and
the `dawn_cache_inmemory` crate from `dawn_cache`.

Signed-off-by: Zeyla Hellyer <zeyla@hellyer.dev>