### PR TITLE
[http] break out request fields into structs

### DIFF
--- a/http/src/request/create_guild.rs
+++ b/http/src/request/create_guild.rs
@@ -9,42 +9,45 @@ use dawn_model::{
         VerificationLevel,
     },
 };
-use serde::Serialize;
 
 #[derive(Serialize)]
-pub struct CreateGuild<'a> {
+struct CreateGuildFields {
     channels: Option<Vec<GuildChannel>>,
     default_message_notifications: Option<DefaultMessageNotificationLevel>,
     explicit_content_filter: Option<ExplicitContentFilter>,
     icon: Option<String>,
+    name: String,
     region: Option<String>,
     roles: Option<Vec<Role>>,
     verification_level: Option<VerificationLevel>,
-    #[serde(skip)]
+}
+
+pub struct CreateGuild<'a> {
+    fields: CreateGuildFields,
     fut: Option<Pending<'a, PartialGuild>>,
-    #[serde(skip)]
     http: &'a Client,
-    name: String,
 }
 
 impl<'a> CreateGuild<'a> {
     pub(crate) fn new(http: &'a Client, name: impl Into<String>) -> Self {
         Self {
-            channels: None,
-            default_message_notifications: None,
-            explicit_content_filter: None,
+            fields: CreateGuildFields {
+                channels: None,
+                default_message_notifications: None,
+                explicit_content_filter: None,
+                icon: None,
+                name: name.into(),
+                region: None,
+                roles: None,
+                verification_level: None,
+            },
             fut: None,
             http,
-            icon: None,
-            name: name.into(),
-            region: None,
-            roles: None,
-            verification_level: None,
         }
     }
 
     pub fn channels(mut self, channels: Vec<GuildChannel>) -> Self {
-        self.channels.replace(channels);
+        self.fields.channels.replace(channels);
 
         self
     }
@@ -53,7 +56,8 @@ impl<'a> CreateGuild<'a> {
         mut self,
         default_message_notifications: DefaultMessageNotificationLevel,
     ) -> Self {
-        self.default_message_notifications
+        self.fields
+            .default_message_notifications
             .replace(default_message_notifications);
 
         self
@@ -63,33 +67,34 @@ impl<'a> CreateGuild<'a> {
         mut self,
         explicit_content_filter: ExplicitContentFilter,
     ) -> Self {
-        self.explicit_content_filter
+        self.fields
+            .explicit_content_filter
             .replace(explicit_content_filter);
 
         self
     }
 
     pub fn icon(mut self, icon: impl Into<String>) -> Self {
-        self.icon.replace(icon.into());
+        self.fields.icon.replace(icon.into());
 
         self
     }
 
     pub fn region(mut self, region: impl Into<String>) -> Self {
-        self.region.replace(region.into());
+        self.fields.region.replace(region.into());
 
         self
     }
 
     pub fn roles(mut self, roles: Vec<Role>) -> Self {
-        self.roles.replace(roles);
+        self.fields.roles.replace(roles);
 
         self
     }
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(self)?,
+            serde_json::to_vec(&self.fields)?,
             Route::CreateGuild,
         )))));
 

--- a/http/src/request/create_guild_channel.rs
+++ b/http/src/request/create_guild_channel.rs
@@ -3,13 +3,13 @@ use dawn_model::{
     channel::{permission_overwrite::PermissionOverwrite, ChannelType, GuildChannel},
     id::{ChannelId, GuildId},
 };
-use serde::Serialize;
 
 #[derive(Serialize)]
-pub struct CreateGuildChannel<'a> {
+struct CreateGuildChannelFields {
     bitrate: Option<u64>,
     #[serde(rename = "type")]
     kind: Option<ChannelType>,
+    name: String,
     nsfw: Option<bool>,
     parent_id: Option<ChannelId>,
     permission_overwrites: Option<Vec<PermissionOverwrite>>,
@@ -17,13 +17,13 @@ pub struct CreateGuildChannel<'a> {
     rate_limit_per_user: Option<u64>,
     topic: Option<String>,
     user_limit: Option<u64>,
-    #[serde(skip)]
+}
+
+pub struct CreateGuildChannel<'a> {
+    fields: CreateGuildChannelFields,
     fut: Option<Pending<'a, GuildChannel>>,
-    #[serde(skip)]
     guild_id: GuildId,
-    #[serde(skip)]
     http: &'a Client,
-    name: String,
 }
 
 impl<'a> CreateGuildChannel<'a> {
@@ -33,42 +33,44 @@ impl<'a> CreateGuildChannel<'a> {
         name: impl Into<String>,
     ) -> Self {
         Self {
-            bitrate: None,
+            fields: CreateGuildChannelFields {
+                bitrate: None,
+                kind: None,
+                name: name.into(),
+                nsfw: None,
+                parent_id: None,
+                permission_overwrites: None,
+                position: None,
+                rate_limit_per_user: None,
+                topic: None,
+                user_limit: None,
+            },
             fut: None,
             guild_id: guild_id.into(),
             http,
-            kind: None,
-            name: name.into(),
-            nsfw: None,
-            parent_id: None,
-            permission_overwrites: None,
-            position: None,
-            rate_limit_per_user: None,
-            topic: None,
-            user_limit: None,
         }
     }
 
     pub fn bitrate(mut self, bitrate: u64) -> Self {
-        self.bitrate.replace(bitrate);
+        self.fields.bitrate.replace(bitrate);
 
         self
     }
 
     pub fn kind(mut self, kind: ChannelType) -> Self {
-        self.kind.replace(kind);
+        self.fields.kind.replace(kind);
 
         self
     }
 
     pub fn nsfw(mut self, nsfw: bool) -> Self {
-        self.nsfw.replace(nsfw);
+        self.fields.nsfw.replace(nsfw);
 
         self
     }
 
     pub fn parent_id(mut self, parent_id: impl Into<ChannelId>) -> Self {
-        self.parent_id.replace(parent_id.into());
+        self.fields.parent_id.replace(parent_id.into());
 
         self
     }
@@ -77,38 +79,40 @@ impl<'a> CreateGuildChannel<'a> {
         mut self,
         permission_overwrites: Vec<PermissionOverwrite>,
     ) -> Self {
-        self.permission_overwrites.replace(permission_overwrites);
+        self.fields
+            .permission_overwrites
+            .replace(permission_overwrites);
 
         self
     }
 
     pub fn position(mut self, position: u64) -> Self {
-        self.position.replace(position);
+        self.fields.position.replace(position);
 
         self
     }
 
     pub fn rate_limit_per_user(mut self, rate_limit_per_user: u64) -> Self {
-        self.rate_limit_per_user.replace(rate_limit_per_user);
+        self.fields.rate_limit_per_user.replace(rate_limit_per_user);
 
         self
     }
 
     pub fn topic(mut self, topic: impl Into<String>) -> Self {
-        self.topic.replace(topic.into());
+        self.fields.topic.replace(topic.into());
 
         self
     }
 
     pub fn user_limit(mut self, user_limit: u64) -> Self {
-        self.user_limit.replace(user_limit);
+        self.fields.user_limit.replace(user_limit);
 
         self
     }
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(self)?,
+            serde_json::to_vec(&self.fields)?,
             Route::CreateChannel {
                 guild_id: self.guild_id.0,
             },

--- a/http/src/request/create_guild_prune.rs
+++ b/http/src/request/create_guild_prune.rs
@@ -1,23 +1,25 @@
 use super::prelude::*;
 use dawn_model::{guild::GuildPrune, id::GuildId};
 
-#[derive(Serialize)]
-pub struct CreateGuildPrune<'a> {
+struct CreateGuildPruneFields {
     compute_prune_count: Option<bool>,
     days: Option<u64>,
-    #[serde(skip)]
+}
+
+pub struct CreateGuildPrune<'a> {
+    fields: CreateGuildPruneFields,
     guild_id: GuildId,
-    #[serde(skip)]
     fut: Option<Pending<'a, Option<GuildPrune>>>,
-    #[serde(skip)]
     http: &'a Client,
 }
 
 impl<'a> CreateGuildPrune<'a> {
     pub(crate) fn new(http: &'a Client, guild_id: impl Into<GuildId>) -> Self {
         Self {
-            compute_prune_count: None,
-            days: None,
+            fields: CreateGuildPruneFields {
+                compute_prune_count: None,
+                days: None,
+            },
             fut: None,
             guild_id: guild_id.into(),
             http,
@@ -25,13 +27,13 @@ impl<'a> CreateGuildPrune<'a> {
     }
 
     pub fn compute_prune_count(mut self, compute_prune_count: bool) -> Self {
-        self.compute_prune_count.replace(compute_prune_count);
+        self.fields.compute_prune_count.replace(compute_prune_count);
 
         self
     }
 
     pub fn days(mut self, days: u64) -> Self {
-        self.days.replace(days);
+        self.fields.days.replace(days);
 
         self
     }
@@ -39,8 +41,8 @@ impl<'a> CreateGuildPrune<'a> {
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from(
             Route::CreateGuildPrune {
-                compute_prune_count: self.compute_prune_count,
-                days: self.days,
+                compute_prune_count: self.fields.compute_prune_count,
+                days: self.fields.days,
                 guild_id: self.guild_id.0,
             },
         ))));

--- a/http/src/request/create_message.rs
+++ b/http/src/request/create_message.rs
@@ -4,76 +4,72 @@ use dawn_model::{
     id::ChannelId,
 };
 
-#[derive(Serialize)]
-pub struct CreateMessage<'a> {
+#[derive(Default, Serialize)]
+struct CreateMessageFields {
     content: Option<String>,
     embed: Option<Embed>,
     file: Option<Vec<u8>>,
     nonce: Option<u64>,
     payload_json: Option<Vec<u8>>,
     tts: Option<bool>,
-    #[serde(skip)]
+}
+
+pub struct CreateMessage<'a> {
     channel_id: ChannelId,
-    #[serde(skip)]
+    fields: CreateMessageFields,
     fut: Option<Pending<'a, Message>>,
-    #[serde(skip)]
     http: &'a Client,
 }
 
 impl<'a> CreateMessage<'a> {
     pub(crate) fn new(http: &'a Client, channel_id: impl Into<ChannelId>) -> Self {
         Self {
-            content: None,
-            embed: None,
-            file: None,
-            nonce: None,
-            payload_json: None,
-            tts: None,
             channel_id: channel_id.into(),
+            fields: CreateMessageFields::default(),
             fut: None,
             http,
         }
     }
 
     pub fn content(mut self, content: impl Into<String>) -> Self {
-        self.content.replace(content.into());
+        self.fields.content.replace(content.into());
 
         self
     }
 
     pub fn embed(mut self, embed: Embed) -> Self {
-        self.embed.replace(embed);
+        self.fields.embed.replace(embed);
 
         self
     }
 
     pub fn file(mut self, file: impl Into<Vec<u8>>) -> Self {
-        self.file.replace(file.into());
+        self.fields.file.replace(file.into());
 
         self
     }
 
     pub fn nonce(mut self, nonce: u64) -> Self {
-        self.nonce.replace(nonce);
+        self.fields.nonce.replace(nonce);
 
         self
     }
 
     pub fn payload_json(mut self, payload_json: impl Into<Vec<u8>>) -> Self {
-        self.payload_json.replace(payload_json.into());
+        self.fields.payload_json.replace(payload_json.into());
 
         self
     }
 
     pub fn tts(mut self, tts: bool) -> Self {
-        self.tts.replace(tts);
+        self.fields.tts.replace(tts);
 
         self
     }
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(self)?,
+            serde_json::to_vec(&self.fields)?,
             Route::CreateMessage {
                 channel_id: self.channel_id.0,
             },

--- a/http/src/request/create_role.rs
+++ b/http/src/request/create_role.rs
@@ -4,68 +4,65 @@ use dawn_model::{
     id::GuildId,
 };
 
-#[derive(Serialize)]
-pub struct CreateRole<'a> {
+#[derive(Default, Serialize)]
+struct CreateRoleFields {
     color: Option<u64>,
     hoist: Option<bool>,
     mentionable: Option<bool>,
     name: Option<String>,
     permissions: Option<Permissions>,
-    #[serde(skip)]
+}
+
+pub struct CreateRole<'a> {
+    fields: CreateRoleFields,
     fut: Option<Pending<'a, Role>>,
-    #[serde(skip)]
     guild_id: GuildId,
-    #[serde(skip)]
     http: &'a Client,
 }
 
 impl<'a> CreateRole<'a> {
     pub(crate) fn new(http: &'a Client, guild_id: impl Into<GuildId>) -> Self {
         Self {
-            color: None,
+            fields: CreateRoleFields::default(),
             fut: None,
             guild_id: guild_id.into(),
             http,
-            hoist: None,
-            mentionable: None,
-            name: None,
-            permissions: None,
         }
     }
 
     pub fn color(mut self, color: u64) -> Self {
-        self.color.replace(color);
+        self.fields.color.replace(color);
 
         self
     }
 
     pub fn hoist(mut self, hoist: bool) -> Self {
-        self.hoist.replace(hoist);
+        self.fields.hoist.replace(hoist);
 
         self
     }
 
     pub fn mentionable(mut self, mentionable: bool) -> Self {
-        self.mentionable.replace(mentionable);
+        self.fields.mentionable.replace(mentionable);
 
         self
     }
 
     pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.name.replace(name.into());
+        self.fields.name.replace(name.into());
 
         self
     }
 
     pub fn permissions(mut self, permissions: Permissions) -> Self {
-        self.permissions.replace(permissions);
+        self.fields.permissions.replace(permissions);
 
         self
     }
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(self)?,
+            serde_json::to_vec(&self.fields)?,
             Route::CreateRole {
                 guild_id: self.guild_id.0,
             },

--- a/http/src/request/delete_webhook.rs
+++ b/http/src/request/delete_webhook.rs
@@ -1,12 +1,13 @@
 use super::prelude::*;
 use dawn_model::id::WebhookId;
 
-#[derive(Serialize)]
-pub struct DeleteWebhook<'a> {
+struct DeleteWebhookParams {
     token: Option<String>,
-    #[serde(skip)]
+}
+
+pub struct DeleteWebhook<'a> {
+    fields: DeleteWebhookParams,
     fut: Option<Pending<'a, ()>>,
-    #[serde(skip)]
     http: &'a Client,
     id: WebhookId,
 }
@@ -14,15 +15,17 @@ pub struct DeleteWebhook<'a> {
 impl<'a> DeleteWebhook<'a> {
     pub(crate) fn new(http: &'a Client, id: impl Into<WebhookId>) -> Self {
         Self {
+            fields: DeleteWebhookParams {
+                token: None,
+            },
             fut: None,
             http,
             id: id.into(),
-            token: None,
         }
     }
 
     pub fn token(mut self, token: impl Into<String>) -> Self {
-        self.token.replace(token.into());
+        self.fields.token.replace(token.into());
 
         self
     }
@@ -31,7 +34,7 @@ impl<'a> DeleteWebhook<'a> {
         self.fut.replace(Box::pin(self.http.verify(Request::from(
             Route::DeleteWebhook {
                 webhook_id: self.id.0,
-                token: self.token.as_ref().map(ToOwned::to_owned),
+                token: self.fields.token.clone(),
             },
         ))));
 

--- a/http/src/request/get_audit_log.rs
+++ b/http/src/request/get_audit_log.rs
@@ -4,11 +4,16 @@ use dawn_model::{
     id::{GuildId, UserId},
 };
 
-pub struct GetAuditLog<'a> {
+#[derive(Default)]
+struct GetAuditLogFields {
     action_type: Option<AuditLogEvent>,
     before: Option<u64>,
     limit: Option<u64>,
     user_id: Option<UserId>,
+}
+
+pub struct GetAuditLog<'a> {
+    fields: GetAuditLogFields,
     fut: Option<Pending<'a, Option<AuditLog>>>,
     guild_id: GuildId,
     http: &'a Client,
@@ -17,36 +22,33 @@ pub struct GetAuditLog<'a> {
 impl<'a> GetAuditLog<'a> {
     pub(crate) fn new(http: &'a Client, guild_id: impl Into<GuildId>) -> Self {
         Self {
-            action_type: None,
-            before: None,
+            fields: GetAuditLogFields::default(),
             fut: None,
             guild_id: guild_id.into(),
             http,
-            limit: None,
-            user_id: None,
         }
     }
 
     pub fn action_type(mut self, action_type: AuditLogEvent) -> Self {
-        self.action_type.replace(action_type);
+        self.fields.action_type.replace(action_type);
 
         self
     }
 
     pub fn before(mut self, before: u64) -> Self {
-        self.before.replace(before);
+        self.fields.before.replace(before);
 
         self
     }
 
     pub fn limit(mut self, limit: u64) -> Self {
-        self.limit.replace(limit);
+        self.fields.limit.replace(limit);
 
         self
     }
 
     pub fn user_id(mut self, user_id: UserId) -> Self {
-        self.user_id.replace(user_id);
+        self.fields.user_id.replace(user_id);
 
         self
     }
@@ -54,11 +56,11 @@ impl<'a> GetAuditLog<'a> {
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from(
             Route::GetAuditLogs {
-                action_type: self.action_type.map(|x| x as u64),
-                before: self.before,
+                action_type: self.fields.action_type.map(|x| x as u64),
+                before: self.fields.before,
                 guild_id: self.guild_id.0,
-                limit: self.limit,
-                user_id: self.user_id.map(|x| x.0),
+                limit: self.fields.limit,
+                user_id: self.fields.user_id.map(|x| x.0),
             },
         ))));
 

--- a/http/src/request/get_channel_messages.rs
+++ b/http/src/request/get_channel_messages.rs
@@ -4,10 +4,15 @@ use dawn_model::{
     id::{ChannelId, MessageId},
 };
 
-pub struct GetChannelMessages<'a> {
+#[derive(Default)]
+struct GetChannelMessagesFields {
     limit: Option<u64>,
-    fut: Option<Pending<'a, Vec<Message>>>,
+}
+
+pub struct GetChannelMessages<'a> {
     channel_id: ChannelId,
+    fields: GetChannelMessagesFields,
+    fut: Option<Pending<'a, Vec<Message>>>,
     http: &'a Client,
 }
 
@@ -15,8 +20,8 @@ impl<'a> GetChannelMessages<'a> {
     pub(crate) fn new(http: &'a Client, channel_id: impl Into<ChannelId>) -> Self {
         Self {
             channel_id: channel_id.into(),
+            fields: GetChannelMessagesFields::default(),
             fut: None,
-            limit: None,
             http,
         }
     }
@@ -28,7 +33,7 @@ impl<'a> GetChannelMessages<'a> {
             Some(message_id),
             None,
             None,
-            self.limit,
+            self.fields.limit,
         )
     }
 
@@ -39,7 +44,7 @@ impl<'a> GetChannelMessages<'a> {
             None,
             Some(message_id),
             None,
-            self.limit,
+            self.fields.limit,
         )
     }
 
@@ -50,12 +55,12 @@ impl<'a> GetChannelMessages<'a> {
             None,
             None,
             Some(message_id),
-            self.limit,
+            self.fields.limit,
         )
     }
 
     pub fn limit(mut self, limit: u64) -> Self {
-        self.limit.replace(limit);
+        self.fields.limit.replace(limit);
 
         self
     }
@@ -67,7 +72,7 @@ impl<'a> GetChannelMessages<'a> {
                 around: None,
                 before: None,
                 channel_id: self.channel_id.0,
-                limit: self.limit,
+                limit: self.fields.limit,
             },
         ))));
 

--- a/http/src/request/get_channel_messages_configured.rs
+++ b/http/src/request/get_channel_messages_configured.rs
@@ -4,15 +4,19 @@ use dawn_model::{
     id::{ChannelId, MessageId},
 };
 
+struct GetChannelMessagesConfiguredFields {
+    limit: Option<u64>,
+}
+
 // nb: after, around, and before are mutually exclusive, so we use this
 // "configured" request to utilize the type system to prevent these from being
 // set in combination.
 pub struct GetChannelMessagesConfigured<'a> {
-    limit: Option<u64>,
     after: Option<MessageId>,
     around: Option<MessageId>,
     before: Option<MessageId>,
     channel_id: ChannelId,
+    fields: GetChannelMessagesConfiguredFields,
     fut: Option<Pending<'a, Vec<Message>>>,
     http: &'a Client,
 }
@@ -31,14 +35,16 @@ impl<'a> GetChannelMessagesConfigured<'a> {
             around,
             before,
             channel_id,
+            fields: GetChannelMessagesConfiguredFields {
+                limit,
+            },
             fut: None,
             http,
-            limit,
         }
     }
 
     pub fn limit(mut self, limit: u64) -> Self {
-        self.limit.replace(limit);
+        self.fields.limit.replace(limit);
 
         self
     }
@@ -50,7 +56,7 @@ impl<'a> GetChannelMessagesConfigured<'a> {
                 around: self.around.map(|x| x.0),
                 before: self.before.map(|x| x.0),
                 channel_id: self.channel_id.0,
-                limit: self.limit,
+                limit: self.fields.limit,
             },
         ))));
 

--- a/http/src/request/get_current_user_guilds.rs
+++ b/http/src/request/get_current_user_guilds.rs
@@ -1,55 +1,57 @@
 use super::prelude::*;
 use dawn_model::{guild::PartialGuild, id::GuildId};
 
-#[derive(Serialize)]
-pub struct GetCurrentUserGuilds<'a> {
+struct GetCurrentUserGuildsFields {
     after: Option<GuildId>,
     before: Option<GuildId>,
-    #[serde(skip)]
-    fut: Option<Pending<'a, Vec<PartialGuild>>>,
-    #[serde(skip)]
-    http: &'a Client,
     limit: Option<u64>,
+}
+
+pub struct GetCurrentUserGuilds<'a> {
+    fields: GetCurrentUserGuildsFields,
+    fut: Option<Pending<'a, Vec<PartialGuild>>>,
+    http: &'a Client,
 }
 
 impl<'a> GetCurrentUserGuilds<'a> {
     pub(crate) fn new(http: &'a Client) -> Self {
         Self {
-            after: None,
-            before: None,
+            fields: GetCurrentUserGuildsFields {
+                after: None,
+                before: None,
+                limit: None,
+            },
             fut: None,
             http,
-            limit: None,
         }
     }
 
     pub fn after(mut self, guild_id: GuildId) -> Self {
-        self.after.replace(guild_id);
+        self.fields.after.replace(guild_id);
 
         self
     }
 
     pub fn before(mut self, guild_id: GuildId) -> Self {
-        self.before.replace(guild_id);
+        self.fields.before.replace(guild_id);
 
         self
     }
 
     pub fn limit(mut self, limit: u64) -> Self {
-        self.limit.replace(limit);
+        self.fields.limit.replace(limit);
 
         self
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(self)?,
+        self.fut.replace(Box::pin(self.http.request(Request::from(
             Route::GetGuilds {
-                after: self.after.map(|x| x.0),
-                before: self.before.map(|x| x.0),
-                limit: self.limit,
+                after: self.fields.after.map(|x| x.0),
+                before: self.fields.before.map(|x| x.0),
+                limit: self.fields.limit,
             },
-        )))));
+        ))));
 
         Ok(())
     }

--- a/http/src/request/get_gateway_authed.rs
+++ b/http/src/request/get_gateway_authed.rs
@@ -1,11 +1,8 @@
 use super::prelude::*;
 use dawn_model::gateway::connection_info::BotConnectionInfo;
 
-#[derive(Serialize)]
 pub struct GetGatewayAuthed<'a> {
-    #[serde(skip)]
     fut: Option<Pending<'a, BotConnectionInfo>>,
-    #[serde(skip)]
     http: &'a Client,
 }
 

--- a/http/src/request/get_guild_members.rs
+++ b/http/src/request/get_guild_members.rs
@@ -4,6 +4,12 @@ use dawn_model::{
     id::{GuildId, UserId},
 };
 
+#[derive(Default)]
+struct GetGuildMembersFields {
+    after: Option<UserId>,
+    limit: Option<u64>,
+}
+
 /// Gets a list of members from a guild.
 ///
 /// # Examples
@@ -28,8 +34,7 @@ use dawn_model::{
 /// # Ok(()) }
 /// ```
 pub struct GetGuildMembers<'a> {
-    after: Option<UserId>,
-    limit: Option<u64>,
+    fields: GetGuildMembersFields,
     fut: Option<Pending<'a, Vec<Member>>>,
     guild_id: GuildId,
     http: &'a Client,
@@ -38,17 +43,16 @@ pub struct GetGuildMembers<'a> {
 impl<'a> GetGuildMembers<'a> {
     pub(crate) fn new(http: &'a Client, guild_id: impl Into<GuildId>) -> Self {
         Self {
-            after: None,
+            fields: GetGuildMembersFields::default(),
             fut: None,
             guild_id: guild_id.into(),
             http,
-            limit: None,
         }
     }
 
     /// Sets the user ID to get members after.
     pub fn after(mut self, after: UserId) -> Self {
-        self.after.replace(after);
+        self.fields.after.replace(after);
 
         self
     }
@@ -57,7 +61,7 @@ impl<'a> GetGuildMembers<'a> {
     ///
     /// The maximum value accepted by the API is 1000.
     pub fn limit(mut self, limit: u64) -> Self {
-        self.limit.replace(limit);
+        self.fields.limit.replace(limit);
 
         self
     }
@@ -65,9 +69,9 @@ impl<'a> GetGuildMembers<'a> {
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from(
             Route::GetGuildMembers {
-                after: self.after.map(|x| x.0),
+                after: self.fields.after.map(|x| x.0),
                 guild_id: self.guild_id.0,
-                limit: self.limit,
+                limit: self.fields.limit,
             },
         ))));
 

--- a/http/src/request/get_guild_prune_count.rs
+++ b/http/src/request/get_guild_prune_count.rs
@@ -1,8 +1,13 @@
 use super::prelude::*;
 use dawn_model::{guild::GuildPrune, id::GuildId};
 
-pub struct GetGuildPruneCount<'a> {
+#[derive(Default)]
+struct GetGuildPruneCountFields {
     days: Option<u64>,
+}
+
+pub struct GetGuildPruneCount<'a> {
+    fields: GetGuildPruneCountFields,
     fut: Option<Pending<'a, GuildPrune>>,
     guild_id: GuildId,
     http: &'a Client,
@@ -11,7 +16,7 @@ pub struct GetGuildPruneCount<'a> {
 impl<'a> GetGuildPruneCount<'a> {
     pub(crate) fn new(http: &'a Client, guild_id: impl Into<GuildId>) -> Self {
         Self {
-            days: None,
+            fields: GetGuildPruneCountFields::default(),
             fut: None,
             guild_id: guild_id.into(),
             http,
@@ -19,7 +24,7 @@ impl<'a> GetGuildPruneCount<'a> {
     }
 
     pub fn days(mut self, days: u64) -> Self {
-        self.days.replace(days);
+        self.fields.days.replace(days);
 
         self
     }
@@ -27,7 +32,7 @@ impl<'a> GetGuildPruneCount<'a> {
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from(
             Route::GetGuildPruneCount {
-                days: self.days,
+                days: self.fields.days,
                 guild_id: self.guild_id.0,
             },
         ))));

--- a/http/src/request/get_invite.rs
+++ b/http/src/request/get_invite.rs
@@ -1,9 +1,14 @@
 use super::prelude::*;
 use dawn_model::invite::Invite;
 
-pub struct GetInvite<'a> {
+#[derive(Default)]
+struct GetInviteFields {
     with_counts: bool,
+}
+
+pub struct GetInvite<'a> {
     code: String,
+    fields: GetInviteFields,
     fut: Option<Pending<'a, Option<Invite>>>,
     http: &'a Client,
 }
@@ -12,14 +17,14 @@ impl<'a> GetInvite<'a> {
     pub(crate) fn new(http: &'a Client, code: impl Into<String>) -> Self {
         Self {
             code: code.into(),
+            fields: GetInviteFields::default(),
             fut: None,
             http,
-            with_counts: false,
         }
     }
 
     pub fn with_counts(mut self) -> Self {
-        self.with_counts = true;
+        self.fields.with_counts = true;
 
         self
     }
@@ -27,8 +32,8 @@ impl<'a> GetInvite<'a> {
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from(
             Route::GetInvite {
-                code: self.code.to_owned(),
-                with_counts: self.with_counts,
+                code: self.code.clone(),
+                with_counts: self.fields.with_counts,
             },
         ))));
 

--- a/http/src/request/get_reactions.rs
+++ b/http/src/request/get_reactions.rs
@@ -4,12 +4,17 @@ use dawn_model::{
     user::User,
 };
 
-pub struct GetReactions<'a> {
+#[derive(Default)]
+struct GetReactionsFields {
     after: Option<UserId>,
     before: Option<UserId>,
     limit: Option<u64>,
+}
+
+pub struct GetReactions<'a> {
     channel_id: ChannelId,
     emoji: String,
+    fields: GetReactionsFields,
     fut: Option<Pending<'a, Vec<User>>>,
     http: &'a Client,
     message_id: MessageId,
@@ -23,31 +28,29 @@ impl<'a> GetReactions<'a> {
         emoji: impl Into<String>,
     ) -> Self {
         Self {
-            after: None,
-            before: None,
             channel_id: channel_id.into(),
             emoji: emoji.into(),
+            fields: GetReactionsFields::default(),
             fut: None,
             http,
-            limit: None,
             message_id: message_id.into(),
         }
     }
 
     pub fn after(mut self, after: UserId) -> Self {
-        self.after.replace(after);
+        self.fields.after.replace(after);
 
         self
     }
 
     pub fn before(mut self, before: UserId) -> Self {
-        self.before.replace(before);
+        self.fields.before.replace(before);
 
         self
     }
 
     pub fn limit(mut self, limit: u64) -> Self {
-        self.limit.replace(limit);
+        self.fields.limit.replace(limit);
 
         self
     }
@@ -55,11 +58,11 @@ impl<'a> GetReactions<'a> {
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from(
             Route::GetReactionUsers {
-                after: self.after.map(|x| x.0),
-                before: self.before.map(|x| x.0),
+                after: self.fields.after.map(|x| x.0),
+                before: self.fields.before.map(|x| x.0),
                 channel_id: self.channel_id.0,
                 emoji: self.emoji.to_owned(),
-                limit: self.limit,
+                limit: self.fields.limit,
                 message_id: self.message_id.0,
             },
         ))));

--- a/http/src/request/get_webhook.rs
+++ b/http/src/request/get_webhook.rs
@@ -1,8 +1,13 @@
 use super::prelude::*;
 use dawn_model::{channel::Webhook, id::WebhookId};
 
-pub struct GetWebhook<'a> {
+#[derive(Default)]
+struct GetWebhookFields {
     token: Option<String>,
+}
+
+pub struct GetWebhook<'a> {
+    fields: GetWebhookFields,
     fut: Option<Pending<'a, Option<Webhook>>>,
     http: &'a Client,
     id: WebhookId,
@@ -11,15 +16,15 @@ pub struct GetWebhook<'a> {
 impl<'a> GetWebhook<'a> {
     pub(crate) fn new(http: &'a Client, id: impl Into<WebhookId>) -> Self {
         Self {
+            fields: GetWebhookFields::default(),
             fut: None,
             http,
             id: id.into(),
-            token: None,
         }
     }
 
     pub fn token(mut self, token: impl Into<String>) -> Self {
-        self.token.replace(token.into());
+        self.fields.token.replace(token.into());
 
         self
     }
@@ -27,7 +32,7 @@ impl<'a> GetWebhook<'a> {
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from(
             Route::GetWebhook {
-                token: self.token.as_ref().map(ToOwned::to_owned),
+                token: self.fields.token.clone(),
                 webhook_id: self.id.0,
             },
         ))));

--- a/http/src/request/prelude.rs
+++ b/http/src/request/prelude.rs
@@ -1,5 +1,9 @@
 pub(super) use super::{Pending, Request};
-pub use crate::{client::Client, error::Result, routing::Route};
+pub use crate::{
+    client::Client,
+    error::{Error, Result},
+    routing::Route,
+};
 pub use reqwest::Method;
 pub use serde::{Deserialize, Serialize};
 pub use std::{

--- a/http/src/request/update_channel.rs
+++ b/http/src/request/update_channel.rs
@@ -4,8 +4,8 @@ use dawn_model::{
     id::ChannelId,
 };
 
-#[derive(Serialize)]
-pub struct UpdateChannel<'a> {
+#[derive(Default, Serialize)]
+struct UpdateChannelFields {
     bitrate: Option<u64>,
     name: Option<String>,
     nsfw: Option<bool>,
@@ -15,52 +15,45 @@ pub struct UpdateChannel<'a> {
     rate_limit_per_user: Option<u64>,
     topic: Option<String>,
     user_limit: Option<u64>,
-    #[serde(skip)]
+}
+
+pub struct UpdateChannel<'a> {
     channel_id: ChannelId,
-    #[serde(skip)]
+    fields: UpdateChannelFields,
     fut: Option<Pending<'a, Channel>>,
-    #[serde(skip)]
     http: &'a Client,
 }
 
 impl<'a> UpdateChannel<'a> {
     pub(crate) fn new(http: &'a Client, channel_id: impl Into<ChannelId>) -> Self {
         Self {
-            bitrate: None,
-            name: None,
-            nsfw: None,
-            parent_id: None,
-            permission_overwrites: None,
-            position: None,
-            rate_limit_per_user: None,
-            topic: None,
-            user_limit: None,
             channel_id: channel_id.into(),
+            fields: UpdateChannelFields::default(),
             fut: None,
             http,
         }
     }
 
     pub fn bitrate(mut self, bitrate: u64) -> Self {
-        self.bitrate.replace(bitrate);
+        self.fields.bitrate.replace(bitrate);
 
         self
     }
 
     pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.name.replace(name.into());
+        self.fields.name.replace(name.into());
 
         self
     }
 
     pub fn nsfw(mut self, nsfw: bool) -> Self {
-        self.nsfw.replace(nsfw);
+        self.fields.nsfw.replace(nsfw);
 
         self
     }
 
     pub fn parent_id(mut self, parent_id: ChannelId) -> Self {
-        self.parent_id.replace(parent_id);
+        self.fields.parent_id.replace(parent_id);
 
         self
     }
@@ -69,38 +62,40 @@ impl<'a> UpdateChannel<'a> {
         mut self,
         permission_overwrites: Vec<PermissionOverwrite>,
     ) -> Self {
-        self.permission_overwrites.replace(permission_overwrites);
+        self.fields
+            .permission_overwrites
+            .replace(permission_overwrites);
 
         self
     }
 
     pub fn position(mut self, position: u64) -> Self {
-        self.position.replace(position);
+        self.fields.position.replace(position);
 
         self
     }
 
     pub fn rate_limit_per_user(mut self, rate_limit_per_user: u64) -> Self {
-        self.rate_limit_per_user.replace(rate_limit_per_user);
+        self.fields.rate_limit_per_user.replace(rate_limit_per_user);
 
         self
     }
 
     pub fn topic(mut self, topic: impl Into<String>) -> Self {
-        self.topic.replace(topic.into());
+        self.fields.topic.replace(topic.into());
 
         self
     }
 
     pub fn user_limit(mut self, user_limit: u64) -> Self {
-        self.user_limit.replace(user_limit);
+        self.fields.user_limit.replace(user_limit);
 
         self
     }
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(self)?,
+            serde_json::to_vec(&self.fields)?,
             Route::UpdateChannel {
                 channel_id: self.channel_id.0,
             },

--- a/http/src/request/update_current_user.rs
+++ b/http/src/request/update_current_user.rs
@@ -1,41 +1,42 @@
 use super::prelude::*;
 use dawn_model::user::User;
 
-#[derive(Serialize)]
-pub struct UpdateCurrentUser<'a> {
+#[derive(Default, Serialize)]
+struct UpdateCurrentUserFields {
     avatar: Option<String>,
     username: Option<String>,
-    #[serde(skip)]
+}
+
+pub struct UpdateCurrentUser<'a> {
+    fields: UpdateCurrentUserFields,
     fut: Option<Pending<'a, User>>,
-    #[serde(skip)]
     http: &'a Client,
 }
 
 impl<'a> UpdateCurrentUser<'a> {
     pub(crate) fn new(http: &'a Client) -> Self {
         Self {
-            avatar: None,
+            fields: UpdateCurrentUserFields::default(),
             fut: None,
             http,
-            username: None,
         }
     }
 
     pub fn avatar(mut self, avatar: impl Into<String>) -> Self {
-        self.avatar.replace(avatar.into());
+        self.fields.avatar.replace(avatar.into());
 
         self
     }
 
     pub fn username(mut self, username: impl Into<String>) -> Self {
-        self.username.replace(username.into());
+        self.fields.username.replace(username.into());
 
         self
     }
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(&self)?,
+            serde_json::to_vec(&self.fields)?,
             Route::UpdateCurrentUser,
         )))));
 

--- a/http/src/request/update_guild.rs
+++ b/http/src/request/update_guild.rs
@@ -8,10 +8,9 @@ use dawn_model::{
     },
     id::{ChannelId, GuildId, UserId},
 };
-use serde::Serialize;
 
-#[derive(Serialize)]
-pub struct UpdateGuild<'a> {
+#[derive(Default, Serialize)]
+struct UpdateGuildFields {
     afk_channel_id: Option<ChannelId>,
     afk_timeout: Option<u64>,
     default_message_notifications: Option<DefaultMessageNotificationLevel>,
@@ -23,42 +22,33 @@ pub struct UpdateGuild<'a> {
     splash: Option<String>,
     system_channel_id: Option<ChannelId>,
     verification_level: Option<VerificationLevel>,
-    #[serde(skip)]
+}
+
+pub struct UpdateGuild<'a> {
+    fields: UpdateGuildFields,
     fut: Option<Pending<'a, PartialGuild>>,
-    #[serde(skip)]
     guild_id: GuildId,
-    #[serde(skip)]
     http: &'a Client,
 }
 
 impl<'a> UpdateGuild<'a> {
     pub(crate) fn new(http: &'a Client, guild_id: impl Into<GuildId>) -> Self {
         Self {
-            afk_channel_id: None,
-            afk_timeout: None,
-            default_message_notifications: None,
-            explicit_content_filter: None,
+            fields: UpdateGuildFields::default(),
             fut: None,
             guild_id: guild_id.into(),
             http,
-            icon: None,
-            name: None,
-            owner_id: None,
-            region: None,
-            splash: None,
-            system_channel_id: None,
-            verification_level: None,
         }
     }
 
     pub fn afk_channel_id(mut self, afk_channel_id: impl Into<ChannelId>) -> Self {
-        self.afk_channel_id.replace(afk_channel_id.into());
+        self.fields.afk_channel_id.replace(afk_channel_id.into());
 
         self
     }
 
     pub fn afk_timeout(mut self, afk_timeout: u64) -> Self {
-        self.afk_timeout.replace(afk_timeout);
+        self.fields.afk_timeout.replace(afk_timeout);
 
         self
     }
@@ -67,7 +57,8 @@ impl<'a> UpdateGuild<'a> {
         mut self,
         default_message_notifications: DefaultMessageNotificationLevel,
     ) -> Self {
-        self.default_message_notifications
+        self.fields
+            .default_message_notifications
             .replace(default_message_notifications);
 
         self
@@ -77,57 +68,60 @@ impl<'a> UpdateGuild<'a> {
         mut self,
         explicit_content_filter: ExplicitContentFilter,
     ) -> Self {
-        self.explicit_content_filter
+        self.fields
+            .explicit_content_filter
             .replace(explicit_content_filter);
 
         self
     }
 
     pub fn icon(mut self, icon: impl Into<String>) -> Self {
-        self.icon.replace(icon.into());
+        self.fields.icon.replace(icon.into());
 
         self
     }
 
     pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.name.replace(name.into());
+        self.fields.name.replace(name.into());
 
         self
     }
 
     pub fn owner_id(mut self, owner_id: impl Into<UserId>) -> Self {
-        self.owner_id.replace(owner_id.into());
+        self.fields.owner_id.replace(owner_id.into());
 
         self
     }
 
     pub fn region(mut self, region: impl Into<String>) -> Self {
-        self.region.replace(region.into());
+        self.fields.region.replace(region.into());
 
         self
     }
 
     pub fn splash(mut self, splash: impl Into<String>) -> Self {
-        self.splash.replace(splash.into());
+        self.fields.splash.replace(splash.into());
 
         self
     }
 
     pub fn system_channel_id(mut self, system_channel_id: impl Into<ChannelId>) -> Self {
-        self.system_channel_id.replace(system_channel_id.into());
+        self.fields
+            .system_channel_id
+            .replace(system_channel_id.into());
 
         self
     }
 
     pub fn verification_level(mut self, verification_level: VerificationLevel) -> Self {
-        self.verification_level.replace(verification_level);
+        self.fields.verification_level.replace(verification_level);
 
         self
     }
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(self)?,
+            serde_json::to_vec(&self.fields)?,
             Route::UpdateGuild {
                 guild_id: self.guild_id.0,
             },

--- a/http/src/request/update_guild_embed.rs
+++ b/http/src/request/update_guild_embed.rs
@@ -4,23 +4,23 @@ use dawn_model::{
     id::{ChannelId, GuildId},
 };
 
-#[derive(Serialize)]
-pub struct UpdateGuildEmbed<'a> {
+#[derive(Default, Serialize)]
+struct UpdateGuildEmbedFields {
     channel_id: Option<ChannelId>,
     enabled: Option<bool>,
-    #[serde(skip)]
+}
+
+pub struct UpdateGuildEmbed<'a> {
+    fields: UpdateGuildEmbedFields,
     fut: Option<Pending<'a, GuildEmbed>>,
-    #[serde(skip)]
     guild_id: GuildId,
-    #[serde(skip)]
     http: &'a Client,
 }
 
 impl<'a> UpdateGuildEmbed<'a> {
     pub(crate) fn new(http: &'a Client, guild_id: impl Into<GuildId>) -> Self {
         Self {
-            channel_id: None,
-            enabled: None,
+            fields: UpdateGuildEmbedFields::default(),
             fut: None,
             guild_id: guild_id.into(),
             http,
@@ -28,20 +28,20 @@ impl<'a> UpdateGuildEmbed<'a> {
     }
 
     pub fn channel_id(mut self, channel_id: impl Into<ChannelId>) -> Self {
-        self.channel_id.replace(channel_id.into());
+        self.fields.channel_id.replace(channel_id.into());
 
         self
     }
 
     pub fn enabled(mut self, enabled: bool) -> Self {
-        self.enabled.replace(enabled);
+        self.fields.enabled.replace(enabled);
 
         self
     }
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(self)?,
+            serde_json::to_vec(&self.fields)?,
             Route::UpdateGuildEmbed {
                 guild_id: self.guild_id.0,
             },

--- a/http/src/request/update_role.rs
+++ b/http/src/request/update_role.rs
@@ -4,20 +4,20 @@ use dawn_model::{
     id::{GuildId, RoleId},
 };
 
-#[derive(Serialize)]
-pub struct UpdateRole<'a> {
+#[derive(Default, Serialize)]
+struct UpdateRoleFields {
     color: Option<u64>,
     hoist: Option<bool>,
     mentionable: Option<bool>,
     name: Option<String>,
     permissions: Option<Permissions>,
-    #[serde(skip)]
+}
+
+pub struct UpdateRole<'a> {
+    fields: UpdateRoleFields,
     fut: Option<Pending<'a, Role>>,
-    #[serde(skip)]
     guild_id: GuildId,
-    #[serde(skip)]
     http: &'a Client,
-    #[serde(skip)]
     role_id: RoleId,
 }
 
@@ -28,51 +28,47 @@ impl<'a> UpdateRole<'a> {
         role_id: impl Into<RoleId>,
     ) -> Self {
         Self {
-            color: None,
+            fields: UpdateRoleFields::default(),
             fut: None,
             guild_id: guild_id.into(),
             http,
-            hoist: None,
-            mentionable: None,
-            name: None,
-            permissions: None,
             role_id: role_id.into(),
         }
     }
 
     pub fn color(mut self, color: u64) -> Self {
-        self.color.replace(color);
+        self.fields.color.replace(color);
 
         self
     }
 
     pub fn hoist(mut self, hoist: bool) -> Self {
-        self.hoist.replace(hoist);
+        self.fields.hoist.replace(hoist);
 
         self
     }
 
     pub fn mentionable(mut self, mentionable: bool) -> Self {
-        self.mentionable.replace(mentionable);
+        self.fields.mentionable.replace(mentionable);
 
         self
     }
 
     pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.name.replace(name.into());
+        self.fields.name.replace(name.into());
 
         self
     }
 
     pub fn permissions(mut self, permissions: Permissions) -> Self {
-        self.permissions.replace(permissions);
+        self.fields.permissions.replace(permissions);
 
         self
     }
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(self)?,
+            serde_json::to_vec(&self.fields)?,
             Route::UpdateRole {
                 guild_id: self.guild_id.0,
                 role_id: self.role_id.0,

--- a/http/src/request/update_webhook_with_token.rs
+++ b/http/src/request/update_webhook_with_token.rs
@@ -1,19 +1,17 @@
 use super::prelude::*;
-use crate::Result;
 use dawn_model::{channel::Webhook, id::WebhookId};
-use futures_util::FutureExt;
 
-#[derive(Serialize)]
-pub struct UpdateWebhookWithToken<'a> {
+#[derive(Default, Serialize)]
+struct UpdateWebhookWithTokenFields {
     avatar: Option<String>,
     name: Option<String>,
-    #[serde(skip)]
+}
+
+pub struct UpdateWebhookWithToken<'a> {
+    fields: UpdateWebhookWithTokenFields,
     fut: Option<Pending<'a, Webhook>>,
-    #[serde(skip)]
     http: &'a Client,
-    #[serde(skip)]
     token: String,
-    #[serde(skip)]
     webhook_id: WebhookId,
 }
 
@@ -24,39 +22,34 @@ impl<'a> UpdateWebhookWithToken<'a> {
         token: impl Into<String>,
     ) -> Self {
         Self {
-            avatar: None,
+            fields: UpdateWebhookWithTokenFields::default(),
             fut: None,
             http,
-            name: None,
             token: token.into(),
             webhook_id: webhook_id.into(),
         }
     }
 
     pub fn avatar(mut self, avatar: impl Into<String>) -> Self {
-        self.avatar.replace(avatar.into());
+        self.fields.avatar.replace(avatar.into());
 
         self
     }
 
     pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.name.replace(name.into());
+        self.fields.name.replace(name.into());
 
         self
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(
-            self.http
-                .request(Request::from((
-                    serde_json::to_vec(&self)?,
-                    Route::UpdateWebhook {
-                        token: Some(self.token.clone()),
-                        webhook_id: self.webhook_id.0,
-                    },
-                )))
-                .boxed(),
-        );
+        self.fut.replace(Box::pin(self.http.request(Request::from((
+            serde_json::to_vec(&self.fields)?,
+            Route::UpdateWebhook {
+                token: Some(self.token.clone()),
+                webhook_id: self.webhook_id.0,
+            },
+        )))));
 
         Ok(())
     }


### PR DESCRIPTION
Break out each of the Request structs in the `request` module into,
generally, two structs: the request struct itself and a struct of fields
which can be serialized.

This removes the need for requests themselves to implement Serialize,
which required that a lot of the request structs' fields be marked as
`#[serde(skip)]`.

Signed-off-by: Zeyla Hellyer <zeyla@hellyer.dev>