### PR TITLE
[ci] fix workspace use in actions

### DIFF
--- a/.github/workflows/grcov.yml
+++ b/.github/workflows/grcov.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --all-features
+          args: --workspace
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,4 +47,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --workspace -- --check
+          args: -- --check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --workspace
   rustfmt:
     name: Format
     runs-on: ubuntu-latest
@@ -47,4 +47,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: --workspace -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,24 +3,6 @@ on: [push, pull_request]
 name: Test
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v1
-
-      - name: Install beta toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: beta
-          override: true
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -70,7 +70,7 @@
     unused,
     warnings
 )]
-#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
 
 mod arguments;
 mod config;

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -6,7 +6,7 @@
     rust_2018_idioms,
     unsafe_code
 )]
-#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
 
 pub mod cluster;
 pub mod queue;

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -7,7 +7,11 @@
     unused,
     warnings
 )]
-#![allow(clippy::module_name_repetitions, clippy::pub_enum_variant_names)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::pub_enum_variant_names
+)]
 
 pub mod client;
 pub mod error;

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -72,7 +72,7 @@
     unused,
     warnings
 )]
-#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
 
 pub mod channel;
 pub mod gateway;


### PR DESCRIPTION
Workspaces don't support `--all-features` in commands like `cargo test`,
which is a silent error and ignored, but fails our CI. To fix this,
remove the flag.

Additionally, switch out the deprecated `--all` for the new
`--workspace` flag, and remove the `cargo check` action since it's
covered by the `cargo test` action.

Signed-off-by: Zeyla Hellyer <zeyla@hellyer.dev>