### PR TITLE
[gateway] queue shards before connecting

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -42,6 +42,10 @@ pub struct ShardProcessor {
 
 impl ShardProcessor {
     pub async fn new(config: Arc<Config>) -> Result<Self> {
+        debug!("[ShardProcessor {:?}] Queueing", config.shard());
+        config.queue.request().await;
+        debug!("[ShardProcessor {:?}] Finished queue", config.shard());
+
         let properties = IdentifyProperties::new("dawn.rs", "dawn.rs", OS, "", "");
 
         let url = "wss://gateway.discord.gg?compress=zlib-stream";


### PR DESCRIPTION
Before starting a connection, put in a request to the queue and wait for
it to be realized. This will ensure that only one shard is connecting at
a time, due to the ratelimit around how often shards can connect.

Closes #34.

Signed-off-by: Zeyla Hellyer <zeyla@hellyer.dev>