### PR TITLE
[gateway] request gateway URL on every connection

### DIFF
--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -204,7 +204,8 @@ impl ConfigBuilder {
     ///
     /// By default, the default client is used.
     pub fn http_client(&mut self, http_client: Client) -> &mut Self {
-        self.0.http_client = http_client;
+        self.0.http_client = http_client.clone();
+        self.1.http_client(http_client);
 
         self
     }

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -1,5 +1,6 @@
 use super::{Error, Result};
 use crate::queue::{LocalQueue, Queue};
+use dawn_http::Client as HttpClient;
 use dawn_model::gateway::payload::update_status::UpdateStatusInfo;
 
 /// The configuration used by the shard to identify with the gateway and
@@ -11,6 +12,7 @@ use dawn_model::gateway::payload::update_status::UpdateStatusInfo;
 #[derive(Debug)]
 pub struct Config {
     guild_subscriptions: bool,
+    http_client: HttpClient,
     large_threshold: u64,
     presence: Option<UpdateStatusInfo>,
     pub(crate) queue: Box<dyn Queue + Send + Sync>,
@@ -32,6 +34,11 @@ impl Config {
     /// events.
     pub fn guild_subscriptions(&self) -> bool {
         self.guild_subscriptions
+    }
+
+    /// Returns the `dawn_http` client to be used by the shard.
+    pub fn http_client(&self) -> &HttpClient {
+        &self.http_client
     }
 
     /// The maximum threshold at which point the gateway will stop sending
@@ -92,6 +99,7 @@ impl ConfigBuilder {
 
         Self(Config {
             guild_subscriptions: true,
+            http_client: HttpClient::new(token.clone()),
             large_threshold: 250,
             presence: None,
             queue: Box::new(LocalQueue::new()),
@@ -113,6 +121,13 @@ impl ConfigBuilder {
     /// The default value is `true`.
     pub fn guild_subscriptions(&mut self, guild_subscriptions: bool) -> &mut Self {
         self.0.guild_subscriptions = guild_subscriptions;
+
+        self
+    }
+
+    /// The HTTP client to be used by the shard for getting gateway information.
+    pub fn http_client(&mut self, http_client: HttpClient) -> &mut Self {
+        self.0.http_client = http_client;
 
         self
     }

--- a/gateway/src/shard/error.rs
+++ b/gateway/src/shard/error.rs
@@ -71,9 +71,9 @@ impl Display for Error {
             Self::Connecting {
                 ..
             } => f.write_str("An issue occurred connecting to the gateway"),
-            Self::GettingGatewayUrl { .. } => {
-                f.write_str("Getting the gateway URL failed")
-            },
+            Self::GettingGatewayUrl {
+                ..
+            } => f.write_str("Getting the gateway URL failed"),
             Self::IdTooLarge {
                 id,
                 total,
@@ -107,7 +107,9 @@ impl StdError for Error {
             Self::Connecting {
                 source,
             } => Some(source),
-            Self::GettingGatewayUrl { source } => Some(source),
+            Self::GettingGatewayUrl {
+                source,
+            } => Some(source),
             Self::ParsingUrl {
                 source, ..
             } => Some(source),

--- a/gateway/src/shard/error.rs
+++ b/gateway/src/shard/error.rs
@@ -1,5 +1,6 @@
 //! The error type of why errors occur in the shard module.
 
+use dawn_http::Error as HttpError;
 use flate2::DecompressError;
 use futures_channel::mpsc::TrySendError;
 use serde_json::Error as JsonError;
@@ -24,6 +25,11 @@ pub enum Error {
     Connecting {
         /// The error from the WebSocket client.
         source: TungsteniteError,
+    },
+    /// Getting the gateway URL via the HTTP client failed.
+    GettingGatewayUrl {
+        /// The error from the `dawn_http` client.
+        source: HttpError,
     },
     /// The shard ID was larger than the total number of shards.
     IdTooLarge {
@@ -65,6 +71,9 @@ impl Display for Error {
             Self::Connecting {
                 ..
             } => f.write_str("An issue occurred connecting to the gateway"),
+            Self::GettingGatewayUrl { .. } => {
+                f.write_str("Getting the gateway URL failed")
+            },
             Self::IdTooLarge {
                 id,
                 total,
@@ -98,6 +107,7 @@ impl StdError for Error {
             Self::Connecting {
                 source,
             } => Some(source),
+            Self::GettingGatewayUrl { source } => Some(source),
             Self::ParsingUrl {
                 source, ..
             } => Some(source),

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -44,9 +44,14 @@ impl ShardProcessor {
     pub async fn new(config: Arc<Config>) -> Result<Self> {
         let properties = IdentifyProperties::new("dawn.rs", "dawn.rs", OS, "", "");
 
-        let mut url = config.http_client().gateway().await.map_err(|source| Error::GettingGatewayUrl {
-            source,
-        })?.url;
+        let mut url = config
+            .http_client()
+            .gateway()
+            .await
+            .map_err(|source| Error::GettingGatewayUrl {
+                source,
+            })?
+            .url;
         url.push_str("?v=6&compress=zlib-stream");
 
         let stream = connect::connect(&url).await?;

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -44,9 +44,12 @@ impl ShardProcessor {
     pub async fn new(config: Arc<Config>) -> Result<Self> {
         let properties = IdentifyProperties::new("dawn.rs", "dawn.rs", OS, "", "");
 
-        let url = "wss://gateway.discord.gg?compress=zlib-stream";
+        let mut url = config.http_client().gateway().await.map_err(|source| Error::GettingGatewayUrl {
+            source,
+        })?.url;
+        url.push_str("?v=6&compress=zlib-stream");
 
-        let stream = connect::connect(url).await?;
+        let stream = connect::connect(&url).await?;
         let (mut forwarder, rx, tx) = SocketForwarder::new(stream);
         tokio_executor::spawn(async move {
             forwarder.run().await;


### PR DESCRIPTION
Whenever a shard starts a connection, first get the connection from the
HTTP API via a `dawn_http` client. This ensures that the shard has the
most up-to-date URL for the gateway, which should not be hardcoded.

Closes #35.

Signed-off-by: Zeyla Hellyer <zeyla@hellyer.dev>