### PR TITLE
Fix deadlocks in cache

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -666,7 +666,7 @@ impl InMemoryCache {
     async fn cache_user(&self, user: User) -> Arc<User> {
         match self.0.users.lock().await.get(&user.id) {
             Some(u) if **u == user => return Arc::clone(&u),
-            Some(_) | None => { },
+            Some(_) | None => {},
         }
         let user = Arc::new(user);
         self.0.users.lock().await.insert(user.id, Arc::clone(&user));


### PR DESCRIPTION
Deadlocsk would happen because it tried to aquire a lock while the
lock was locked in the scope.

Signed-off-by: Valdemar Erk <valdemar@erk.io>


----

#