### PR TITLE
Unicode reactions does not deserialize

### DIFF
--- a/cache/in-memory/src/shard.rs
+++ b/cache/in-memory/src/shard.rs
@@ -280,6 +280,7 @@ impl UpdateCache<InMemoryCache, InMemoryCacheError> for Box<VoiceStateUpdate> {
 
 #[async_trait]
 impl UpdateCache<InMemoryCache, InMemoryCacheError> for Event {
+    #[allow(clippy::cognitive_complexity)]
     async fn update(&self, c: &InMemoryCache) -> Result<(), InMemoryCacheError> {
         use dawn_gateway::shard::event::Event::*;
 


### PR DESCRIPTION
Currently unicode reactions currently throw an error like:
```
Error receiveing gateway event: Some(Error("data did not match any variant of untagged enum ReactionType", line: 1, column: 777))
```