### PR TITLE
Use the `futures` crate instead of multiple sub crates.

### DIFF
--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 [dependencies]
 async-trait = "0.1"
 bitflags = "1"
-futures-util = "0.3"
+futures = "0.3"
 dawn-cache-trait = { path = "../trait" }
 dawn-model = { default-features = false, path = "../../model" }
 dawn-gateway = { path = "../../gateway"}

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -15,7 +15,7 @@ use dawn_model::{
     user::{CurrentUser, User},
     voice::VoiceState,
 };
-use futures_util::{future, lock::Mutex};
+use futures::{future, lock::Mutex};
 use std::{
     collections::{
         hash_map::{Entry, HashMap},

--- a/cache/in-memory/src/shard.rs
+++ b/cache/in-memory/src/shard.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use dawn_cache_trait::UpdateCache;
 use dawn_gateway::shard::event::Event;
 use dawn_model::{gateway::payload::*, guild::GuildStatus, id::GuildId};
-use futures_util::lock::Mutex;
+use futures::lock::Mutex;
 #[allow(unused_imports)]
 use log::debug;
 use std::{

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -7,7 +7,7 @@ use dawn_model::{
     guild::GuildStatus,
     id::GuildId,
 };
-use futures_util::lock::Mutex;
+use futures::lock::Mutex;
 #[allow(unused_imports)]
 use log::debug;
 use std::{

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -17,8 +17,7 @@ async-trait = "0.1"
 bitflags = "1"
 dawn-http = { path = "../http" }
 dawn-model = { path = "../model" }
-futures-channel = "0.3"
-futures-util = "0.3"
+futures = "0.3"
 log = "0.4"
 serde = { features = ["derive"], version = "1" }
 serde_json = "1"

--- a/gateway/src/cluster/event.rs
+++ b/gateway/src/cluster/event.rs
@@ -1,6 +1,6 @@
 use crate::shard::Event;
-use futures_channel::mpsc::UnboundedReceiver;
-use futures_util::stream::Stream;
+use futures::channel::mpsc::UnboundedReceiver;
+use futures::stream::Stream;
 use std::{
     pin::Pin,
     task::{Context, Poll},

--- a/gateway/src/cluster/event.rs
+++ b/gateway/src/cluster/event.rs
@@ -1,6 +1,5 @@
 use crate::shard::Event;
-use futures::channel::mpsc::UnboundedReceiver;
-use futures::stream::Stream;
+use futures::{channel::mpsc::UnboundedReceiver, stream::Stream};
 use std::{
     pin::Pin,
     task::{Context, Poll},

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -7,7 +7,7 @@ use crate::{
     queue::{LocalQueue, Queue},
     shard::{event::EventType, Config as ShardConfig, Information, Shard},
 };
-use futures_util::{future, lock::Mutex};
+use futures::{future, lock::Mutex};
 use std::{
     collections::HashMap,
     sync::{Arc, Weak},

--- a/gateway/src/listener.rs
+++ b/gateway/src/listener.rs
@@ -1,6 +1,6 @@
 use crate::shard::EventType;
-use futures_channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use futures_util::lock::Mutex;
+use futures::channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use futures::lock::Mutex;
 use std::{
     collections::HashMap,
     sync::{

--- a/gateway/src/listener.rs
+++ b/gateway/src/listener.rs
@@ -1,6 +1,8 @@
 use crate::shard::EventType;
-use futures::channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use futures::lock::Mutex;
+use futures::{
+    channel::mpsc::{self, UnboundedReceiver, UnboundedSender},
+    lock::Mutex,
+};
 use std::{
     collections::HashMap,
     sync::{

--- a/gateway/src/queue.rs
+++ b/gateway/src/queue.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
-use futures_channel::{
+use futures::channel::{
     mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
     oneshot::{self, Sender},
 };
-use futures_util::{sink::SinkExt, stream::StreamExt};
+use futures::{sink::SinkExt, stream::StreamExt};
 #[allow(unused_imports)]
 use log::{info, warn};
 use std::{fmt::Debug, time::Duration};

--- a/gateway/src/queue.rs
+++ b/gateway/src/queue.rs
@@ -1,9 +1,12 @@
 use async_trait::async_trait;
-use futures::channel::{
-    mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
-    oneshot::{self, Sender},
+use futures::{
+    channel::{
+        mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
+        oneshot::{self, Sender},
+    },
+    sink::SinkExt,
+    stream::StreamExt,
 };
-use futures::{sink::SinkExt, stream::StreamExt};
 #[allow(unused_imports)]
 use log::{info, warn};
 use std::{fmt::Debug, time::Duration};

--- a/gateway/src/shard/error.rs
+++ b/gateway/src/shard/error.rs
@@ -2,7 +2,7 @@
 
 use dawn_http::Error as HttpError;
 use flate2::DecompressError;
-use futures_channel::mpsc::TrySendError;
+use futures::channel::mpsc::TrySendError;
 use serde_json::Error as JsonError;
 use std::{
     error::Error as StdError,

--- a/gateway/src/shard/event.rs
+++ b/gateway/src/shard/event.rs
@@ -15,8 +15,10 @@
 use crate::event::{DispatchEvent, GatewayEvent};
 use bitflags::bitflags;
 use dawn_model::gateway::payload::*;
-use futures::channel::mpsc::UnboundedReceiver;
-use futures::stream::{Stream, StreamExt};
+use futures::{
+    channel::mpsc::UnboundedReceiver,
+    stream::{Stream, StreamExt},
+};
 use std::{
     pin::Pin,
     task::{Context, Poll},

--- a/gateway/src/shard/event.rs
+++ b/gateway/src/shard/event.rs
@@ -15,8 +15,8 @@
 use crate::event::{DispatchEvent, GatewayEvent};
 use bitflags::bitflags;
 use dawn_model::gateway::payload::*;
-use futures_channel::mpsc::UnboundedReceiver;
-use futures_util::stream::{Stream, StreamExt};
+use futures::channel::mpsc::UnboundedReceiver;
+use futures::stream::{Stream, StreamExt};
 use std::{
     pin::Pin,
     task::{Context, Poll},

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -7,7 +7,7 @@ use super::{
     stage::Stage,
 };
 use crate::listener::Listeners;
-use futures_util::future::{self, AbortHandle};
+use futures::future::{self, AbortHandle};
 use log::debug;
 use std::sync::Arc;
 use tokio_tungstenite::tungstenite::Message;

--- a/gateway/src/shard/processor/heartbeat.rs
+++ b/gateway/src/shard/processor/heartbeat.rs
@@ -1,7 +1,6 @@
 use super::super::error::{Error, Result};
 use dawn_model::gateway::payload::Heartbeat;
-use futures::channel::mpsc::UnboundedSender;
-use futures::lock::Mutex;
+use futures::{channel::mpsc::UnboundedSender, lock::Mutex};
 use log::{debug, error, warn};
 use std::{
     collections::VecDeque,

--- a/gateway/src/shard/processor/heartbeat.rs
+++ b/gateway/src/shard/processor/heartbeat.rs
@@ -1,7 +1,7 @@
 use super::super::error::{Error, Result};
 use dawn_model::gateway::payload::Heartbeat;
-use futures_channel::mpsc::UnboundedSender;
-use futures_util::lock::Mutex;
+use futures::channel::mpsc::UnboundedSender;
+use futures::lock::Mutex;
 use log::{debug, error, warn};
 use std::{
     collections::VecDeque,

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -20,8 +20,8 @@ use dawn_model::gateway::payload::{
     identify::{Identify, IdentifyInfo, IdentifyProperties},
     resume::Resume,
 };
-use futures_channel::mpsc::UnboundedReceiver;
-use futures_util::stream::StreamExt;
+use futures::channel::mpsc::UnboundedReceiver;
+use futures::stream::StreamExt;
 #[allow(unused_imports)]
 use log::{debug, info, trace, warn};
 use serde::Serialize;

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -20,8 +20,7 @@ use dawn_model::gateway::payload::{
     identify::{Identify, IdentifyInfo, IdentifyProperties},
     resume::Resume,
 };
-use futures::channel::mpsc::UnboundedReceiver;
-use futures::stream::StreamExt;
+use futures::{channel::mpsc::UnboundedReceiver, stream::StreamExt};
 #[allow(unused_imports)]
 use log::{debug, info, trace, warn};
 use serde::Serialize;

--- a/gateway/src/shard/processor/session.rs
+++ b/gateway/src/shard/processor/session.rs
@@ -6,8 +6,8 @@ use super::{
     heartbeat::{Heartbeater, Heartbeats},
 };
 use dawn_model::gateway::payload::Heartbeat;
-use futures::channel::mpsc::UnboundedSender;
 use futures::{
+    channel::mpsc::UnboundedSender,
     future::{self, AbortHandle},
     lock::Mutex,
 };

--- a/gateway/src/shard/processor/session.rs
+++ b/gateway/src/shard/processor/session.rs
@@ -6,8 +6,8 @@ use super::{
     heartbeat::{Heartbeater, Heartbeats},
 };
 use dawn_model::gateway::payload::Heartbeat;
-use futures_channel::mpsc::UnboundedSender;
-use futures_util::{
+use futures::channel::mpsc::UnboundedSender;
+use futures::{
     future::{self, AbortHandle},
     lock::Mutex,
 };

--- a/gateway/src/shard/processor/socket_forwarder.rs
+++ b/gateway/src/shard/processor/socket_forwarder.rs
@@ -1,6 +1,6 @@
 use super::super::ShardStream;
-use futures::channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use futures::{
+    channel::mpsc::{self, UnboundedReceiver, UnboundedSender},
     future::{self, Either},
     sink::SinkExt,
     stream::StreamExt,

--- a/gateway/src/shard/processor/socket_forwarder.rs
+++ b/gateway/src/shard/processor/socket_forwarder.rs
@@ -1,6 +1,6 @@
 use super::super::ShardStream;
-use futures_channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use futures_util::{
+use futures::channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use futures::{
     future::{self, Either},
     sink::SinkExt,
     stream::StreamExt,

--- a/gateway/src/shard/sink.rs
+++ b/gateway/src/shard/sink.rs
@@ -1,5 +1,7 @@
-use futures::channel::mpsc::{SendError, TrySendError, UnboundedSender};
-use futures::sink::Sink;
+use futures::{
+    channel::mpsc::{SendError, TrySendError, UnboundedSender},
+    sink::Sink,
+};
 use std::{
     pin::Pin,
     task::{Context, Poll},

--- a/gateway/src/shard/sink.rs
+++ b/gateway/src/shard/sink.rs
@@ -1,5 +1,5 @@
-use futures_channel::mpsc::{SendError, TrySendError, UnboundedSender};
-use futures_util::sink::Sink;
+use futures::channel::mpsc::{SendError, TrySendError, UnboundedSender};
+use futures::sink::Sink;
 use std::{
     pin::Pin,
     task::{Context, Poll},

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -13,9 +13,7 @@ repository = "https://github.com/dawn-rs/dawn.git"
 version = "0.1.0"
 
 [dependencies]
-futures-channel = "0.3"
-futures-util = "0.3"
-futures-timer = "2"
+futures = "0.3"
 dawn-model = { path = "../model" }
 log = "0.4"
 reqwest = { default-features = false, features = ["default-tls"], git = "https://github.com/seanmonstar/reqwest.git" }

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -35,6 +35,10 @@ impl ClientBuilder {
         Self::default()
     }
 
+    /// Build the Client
+    ///
+    /// # Errors
+    /// Errors if `reqwest` fails to build the client.
     pub fn build(self) -> Result<Client> {
         let config = self.0.build();
 

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -1,5 +1,5 @@
 use crate::ratelimiting::RatelimitError;
-use futures_channel::oneshot::Canceled;
+use futures::channel::oneshot::Canceled;
 use reqwest::{header::InvalidHeaderValue, Error as ReqwestError, Response as ReqwestResponse};
 use serde_json::Error as JsonError;
 use std::{

--- a/http/src/ratelimiting/bucket.rs
+++ b/http/src/ratelimiting/bucket.rs
@@ -1,11 +1,10 @@
 use super::{headers::RatelimitHeaders, GlobalLockPair};
 use crate::routing::Path;
-use futures_channel::{
+use futures::channel::{
     mpsc::{self, UnboundedReceiver, UnboundedSender},
     oneshot::{self, Sender},
 };
-use futures_timer::Delay;
-use futures_util::{lock::Mutex, stream::StreamExt};
+use futures::{lock::Mutex, stream::StreamExt};
 use log::debug;
 use std::{
     collections::HashMap,
@@ -15,7 +14,7 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use tokio::time::timeout;
+use tokio::time::{delay_for, timeout};
 //use tokio::future::FutureExt as _;
 
 #[derive(Clone, Debug)]
@@ -242,7 +241,7 @@ impl BucketQueueTask {
         debug!("[Bucket {:?}] Request got global ratelimited", self.path,);
         self.global.lock();
         let lock = self.global.0.lock().await;
-        Delay::new(Duration::from_millis(wait)).await;
+        delay_for(Duration::from_millis(wait)).await;
         self.global.unlock();
 
         drop(lock);
@@ -280,7 +279,7 @@ impl BucketQueueTask {
             self.path, wait,
         );
 
-        Delay::new(wait).await;
+        delay_for(wait).await;
 
         debug!(
             "[Bucket {:?}] Done waiting for ratelimit to pass",

--- a/http/src/ratelimiting/bucket.rs
+++ b/http/src/ratelimiting/bucket.rs
@@ -1,10 +1,13 @@
 use super::{headers::RatelimitHeaders, GlobalLockPair};
 use crate::routing::Path;
-use futures::channel::{
-    mpsc::{self, UnboundedReceiver, UnboundedSender},
-    oneshot::{self, Sender},
+use futures::{
+    channel::{
+        mpsc::{self, UnboundedReceiver, UnboundedSender},
+        oneshot::{self, Sender},
+    },
+    lock::Mutex,
+    stream::StreamExt,
 };
-use futures::{lock::Mutex, stream::StreamExt};
 use log::debug;
 use std::{
     collections::HashMap,

--- a/http/src/ratelimiting/mod.rs
+++ b/http/src/ratelimiting/mod.rs
@@ -10,8 +10,8 @@ pub use self::{
 
 use self::bucket::{Bucket, BucketQueueTask};
 use crate::routing::Path;
-use futures_channel::oneshot::{self, Receiver, Sender};
-use futures_util::lock::Mutex;
+use futures::channel::oneshot::{self, Receiver, Sender};
+use futures::lock::Mutex;
 use log::debug;
 use std::{
     collections::hash_map::{Entry, HashMap},

--- a/http/src/ratelimiting/mod.rs
+++ b/http/src/ratelimiting/mod.rs
@@ -10,8 +10,10 @@ pub use self::{
 
 use self::bucket::{Bucket, BucketQueueTask};
 use crate::routing::Path;
-use futures::channel::oneshot::{self, Receiver, Sender};
-use futures::lock::Mutex;
+use futures::{
+    channel::oneshot::{self, Receiver, Sender},
+    lock::Mutex,
+};
 use log::debug;
 use std::{
     collections::hash_map::{Entry, HashMap},

--- a/http/src/request/guild/get_guild_vanity_url.rs
+++ b/http/src/request/guild/get_guild_vanity_url.rs
@@ -1,6 +1,6 @@
 use crate::request::prelude::*;
 use dawn_model::id::GuildId;
-use futures_util::TryFutureExt;
+use futures::TryFutureExt;
 use serde::Deserialize;
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Signed-off-by: Valdemar Erk <valdemar@erk.io>


----

This PR makes it so we uses the `futures` crate in the whole repo
instead of using the sub crates `futures_*` this is to better ensure
compatability between crates and make it easier to update.

The real price to users will likely not be any problem as most will
have the futures crate somewhere in their dependency tree anyway.