### PR TITLE
Fix some routes giving an error back for no reason

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -676,7 +676,11 @@ impl Client {
         let mut builder = self.state.http.request(method.clone(), &url);
 
         if let Some(bytes) = body {
+            let len = bytes.len();
             builder = builder.body(Body::from(bytes));
+            builder = builder.header("content-length", len);
+        } else {
+            builder = builder.header("content-length", 0);
         }
 
         if let Some(ref token) = self.state.token {
@@ -752,7 +756,7 @@ impl Client {
     }
 
     pub async fn verify(&self, request: Request) -> Result<()> {
-        self.raw(request).await?;
+        self.make_request(request).await?;
 
         Ok(())
     }

--- a/http/src/request/channel/create_pin.rs
+++ b/http/src/request/channel/create_pin.rs
@@ -19,7 +19,7 @@ impl<'a> CreatePin<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
+        self.fut.replace(Box::pin(self.http.verify(Request::from(
             Route::PinMessage {
                 channel_id: self.channel_id.0,
                 message_id: self.message_id.0,

--- a/http/src/request/channel/create_typing_trigger.rs
+++ b/http/src/request/channel/create_typing_trigger.rs
@@ -3,7 +3,7 @@ use dawn_model::id::ChannelId;
 
 pub struct CreateTypingTrigger<'a> {
     channel_id: ChannelId,
-    fut: Option<Pending<'a, Option<()>>>,
+    fut: Option<Pending<'a, ()>>,
     http: &'a Client,
 }
 
@@ -27,4 +27,4 @@ impl<'a> CreateTypingTrigger<'a> {
     }
 }
 
-poll_req!(CreateTypingTrigger<'_>, Option<()>);
+poll_req!(CreateTypingTrigger<'_>, ());

--- a/http/src/request/channel/create_typing_trigger.rs
+++ b/http/src/request/channel/create_typing_trigger.rs
@@ -17,7 +17,7 @@ impl<'a> CreateTypingTrigger<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
+        self.fut.replace(Box::pin(self.http.verify(Request::from(
             Route::CreateTypingTrigger {
                 channel_id: self.channel_id.0,
             },

--- a/http/src/request/channel/delete_channel_permission.rs
+++ b/http/src/request/channel/delete_channel_permission.rs
@@ -19,7 +19,7 @@ impl<'a> DeleteChannelPermission<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
+        self.fut.replace(Box::pin(self.http.verify(Request::from(
             Route::DeletePermissionOverwrite {
                 channel_id: self.channel_id.0,
                 target_id: self.target_id,

--- a/http/src/request/channel/delete_pin.rs
+++ b/http/src/request/channel/delete_pin.rs
@@ -19,7 +19,7 @@ impl<'a> DeletePin<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
+        self.fut.replace(Box::pin(self.http.verify(Request::from(
             Route::UnpinMessage {
                 channel_id: self.channel_id.0,
                 message_id: self.message_id.0,

--- a/http/src/request/channel/message/delete_message.rs
+++ b/http/src/request/channel/message/delete_message.rs
@@ -19,7 +19,7 @@ impl<'a> DeleteMessage<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
+        self.fut.replace(Box::pin(self.http.verify(Request::from(
             Route::DeleteMessage {
                 channel_id: self.channel_id.0,
                 message_id: self.message_id.0,

--- a/http/src/request/channel/message/delete_messages.rs
+++ b/http/src/request/channel/message/delete_messages.rs
@@ -30,7 +30,7 @@ impl<'a> DeleteMessages<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
+        self.fut.replace(Box::pin(self.http.verify(Request::from((
             serde_json::to_vec(&self.fields)?,
             Route::DeleteMessages {
                 channel_id: self.channel_id.0,

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -26,7 +26,7 @@ impl<'a> CreateReaction<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
+        self.fut.replace(Box::pin(self.http.verify(Request::from(
             Route::CreateReaction {
                 channel_id: self.channel_id.0,
                 emoji: self.emoji.clone(),

--- a/http/src/request/channel/reaction/delete_reaction.rs
+++ b/http/src/request/channel/reaction/delete_reaction.rs
@@ -29,7 +29,7 @@ impl<'a> DeleteReaction<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
+        self.fut.replace(Box::pin(self.http.verify(Request::from(
             Route::DeleteReaction {
                 channel_id: self.channel_id.0,
                 emoji: self.emoji.clone(),


### PR DESCRIPTION
Discord have some routes that returns a `204 No Content`
when it is correct, as some of them used the `request`
method they would fail when they tried to deserialize
a empty body into a `()`, this commit changes all the
routes that return a `204 No Content` to use the
`verify` method instead of `request`.

Signed-off-by: Valdemar Erk <valdemar@erk.io>