### PR TITLE
Match command with trim_start_matches over starts_with

### DIFF
--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -115,7 +115,7 @@ impl<'a> Parser<'a> {
 
     fn find_command(&'a self, buf: &'a str) -> Option<&'a str> {
         self.config.commands().iter().find_map(|command| {
-            if buf.starts_with(&command[..]) && buf.split_whitespace().next()? == command {
+            if buf.split_whitespace().next()? == command {
                 Some(command.as_ref())
             } else {
                 None

--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -115,7 +115,7 @@ impl<'a> Parser<'a> {
 
     fn find_command(&'a self, buf: &'a str) -> Option<&'a str> {
         self.config.commands().iter().find_map(|command| {
-            if buf.starts_with(&command[..]) {
+            if buf.starts_with(&command[..]) && buf.split_whitespace().next()? == command {
                 Some(command.as_ref())
             } else {
                 None
@@ -150,6 +150,19 @@ mod tests {
         config.add_command("echo");
 
         Parser::new(config)
+    }
+
+    #[test]
+    fn double_command() {
+        let parser = simple_config();
+        match parser.parse("!echoecho") {
+            Some(Command {
+                name, ..
+            }) => {
+                assert_eq!("echoecho", name);
+            },
+            None => (),
+        }
     }
 
     #[test]

--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -156,11 +156,7 @@ mod tests {
     fn double_command() {
         let parser = simple_config();
         match parser.parse("!echoecho") {
-            Some(Command {
-                name, ..
-            }) => {
-                assert_eq!("echoecho", name);
-            },
+            Some(_) => panic!("Double match!"),
             None => (),
         }
     }

--- a/gateway/src/queue.rs
+++ b/gateway/src/queue.rs
@@ -59,7 +59,7 @@ impl LocalQueue {
             waiter(rx).await;
         });
 
-        LocalQueue(tx)
+        Self(tx)
     }
 }
 

--- a/model/src/channel/reaction_type.rs
+++ b/model/src/channel/reaction_type.rs
@@ -65,7 +65,7 @@ mod tests {
     #[test]
     fn test_unicode() {
         let kind = ReactionType::Unicode {
-            name: "🙃".to_owned(),
+            name: "\u{1f643}".to_owned(),
         };
 
         serde_test::assert_de_tokens(
@@ -78,7 +78,7 @@ mod tests {
                 Token::Str("id"),
                 Token::None,
                 Token::Str("name"),
-                Token::Str("🙃"),
+                Token::Str("\u{1f643}"),
                 Token::StructEnd,
             ],
         );


### PR DESCRIPTION
This fixes #80, as if trim_start_matches returns anything at all,
it won't match, over starts_with sometimes matching shorter commands to
longer commands.