### PR TITLE
Restructure and `#[must_use]` on `CommandBuilder`

### DIFF
--- a/command-parser/src/builder/command.rs
+++ b/command-parser/src/builder/command.rs
@@ -1,0 +1,75 @@
+use crate::Config;
+
+/// A builder struct for building commands.
+///
+/// The [`add`] method needs to be called for the command to be added to the  [`Config`].
+///
+/// **Note**: Commands are not case sensitive by default. Use [`case_sensitive`] to enable this.
+///
+/// # Examples
+///
+/// ```rust
+/// use dawn_command_parser::Config;
+///
+/// let mut config = Config::new();
+/// // Adds a case sensitive command to the config.
+/// config.command("ping").case_sensitive().add();
+/// assert_eq!(1, config.commands().len());
+/// ```
+///
+/// [`add`]: #method.add
+/// [`case_sensitive`]: #method.case_sensitive
+/// [`Config`]: struct.Config.html
+pub struct CommandBuilder<'a, 'b> {
+    pub(crate) name: String,
+    pub(crate) case_sensitive: bool,
+    pub(crate) config: &'a mut Config<'b>,
+}
+
+impl<'a, 'b> CommandBuilder<'a, 'b> {
+    /// Adds the command to the [`Config`].
+    ///
+    /// [`Config`]: struct.Config.html
+    pub fn add(self) {
+        self.config.add_command(self.name, self.case_sensitive);
+    }
+
+    /// Makes the command only match if the case is the same.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use dawn_command_parser::{Config, Parser};
+    ///
+    /// let mut config = Config::new();
+    /// config.add_prefix("!");
+    /// config.command("ping").case_sensitive().add();
+    /// let parser = Parser::new(config);
+    /// assert!(parser.parse("!ping should work").is_some());
+    /// assert!(parser.parse("!PiNg shouldn't work").is_none());
+    /// ```
+    pub fn case_sensitive(mut self) -> Self {
+        self.case_sensitive = true;
+        self
+    }
+
+    /// Makes the command match regardless of case.
+    /// This is set by default.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use dawn_command_parser::{Config, Parser};
+    ///
+    /// let mut config = Config::new();
+    /// config.add_prefix("!");
+    /// config.command("ping").case_insensitive().add();
+    /// let parser = Parser::new(config);
+    /// assert!(parser.parse("!ping should work").is_some());
+    /// assert!(parser.parse("!PiNg should also work").is_some());
+    /// ```
+    pub fn case_insensitive(mut self) -> Self {
+        self.case_sensitive = false;
+        self
+    }
+}

--- a/command-parser/src/builder/command.rs
+++ b/command-parser/src/builder/command.rs
@@ -20,6 +20,7 @@ use crate::Config;
 /// [`add`]: #method.add
 /// [`case_sensitive`]: #method.case_sensitive
 /// [`Config`]: struct.Config.html
+#[must_use = "If `add` is not called the command will not be added."]
 pub struct CommandBuilder<'a, 'b> {
     pub(crate) name: String,
     pub(crate) case_sensitive: bool,

--- a/command-parser/src/builder/mod.rs
+++ b/command-parser/src/builder/mod.rs
@@ -1,0 +1,3 @@
+mod command;
+
+pub use command::CommandBuilder;

--- a/command-parser/src/casing.rs
+++ b/command-parser/src/casing.rs
@@ -1,0 +1,25 @@
+use unicase::UniCase;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum CaseSensitivity {
+    Insensitive(UniCase<String>),
+    Sensitive(String),
+}
+
+impl AsRef<str> for CaseSensitivity {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Insensitive(u) => u.as_str(),
+            Self::Sensitive(s) => s.as_str(),
+        }
+    }
+}
+
+impl PartialEq<str> for CaseSensitivity {
+    fn eq(&self, other: &str) -> bool {
+        match self {
+            Self::Insensitive(u) => u == &UniCase::new(other),
+            Self::Sensitive(s) => s == other,
+        }
+    }
+}

--- a/command-parser/src/config.rs
+++ b/command-parser/src/config.rs
@@ -1,9 +1,9 @@
-use unicase::UniCase;
-
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
 };
+
+use crate::{CaseSensitivity, CommandBuilder};
 
 /// Configuration for a [`Parser`].
 ///
@@ -73,7 +73,7 @@ impl<'a> Config<'a> {
         }
     }
 
-    fn add_command(&mut self, name: String, case_sensitive: bool) -> bool {
+    pub(crate) fn add_command(&mut self, name: String, case_sensitive: bool) -> bool {
         let command = if case_sensitive {
             CaseSensitivity::Sensitive(name)
         } else {
@@ -137,104 +137,6 @@ impl<'a> Config<'a> {
     /// ```
     pub fn remove_prefix(&mut self, prefix: impl Into<Cow<'a, str>>) -> Option<Cow<'a, str>> {
         self.prefixes.remove(&prefix.into())
-    }
-}
-
-/// A builder struct for building commands.
-///
-/// The [`add`] method needs to be called for the command to be added to the  [`Config`].
-///
-/// **Note**: Commands are not case sensitive by default. Use [`case_sensitive`] to enable this.
-///
-/// # Examples
-///
-/// ```rust
-/// use dawn_command_parser::Config;
-///
-/// let mut config = Config::new();
-/// // Adds a case sensitive command to the config.
-/// config.command("ping").case_sensitive().add();
-/// assert_eq!(1, config.commands().len());
-/// ```
-///
-/// [`add`]: #method.add
-/// [`case_sensitive`]: #method.case_sensitive
-/// [`Config`]: struct.Config.html
-pub struct CommandBuilder<'a, 'b> {
-    name: String,
-    case_sensitive: bool,
-    config: &'a mut Config<'b>,
-}
-
-impl<'a, 'b> CommandBuilder<'a, 'b> {
-    /// Adds the command to the [`Config`].
-    ///
-    /// [`Config`]: struct.Config.html
-    pub fn add(self) {
-        self.config.add_command(self.name, self.case_sensitive);
-    }
-
-    /// Makes the command only match if the case is the same.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use dawn_command_parser::{Config, Parser};
-    ///
-    /// let mut config = Config::new();
-    /// config.add_prefix("!");
-    /// config.command("ping").case_sensitive().add();
-    /// let parser = Parser::new(config);
-    /// assert!(parser.parse("!ping should work").is_some());
-    /// assert!(parser.parse("!PiNg shouldn't work").is_none());
-    /// ```
-    pub fn case_sensitive(mut self) -> Self {
-        self.case_sensitive = true;
-        self
-    }
-
-    /// Makes the command match regardless of case.
-    /// This is set by default.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use dawn_command_parser::{Config, Parser};
-    ///
-    /// let mut config = Config::new();
-    /// config.add_prefix("!");
-    /// config.command("ping").case_insensitive().add();
-    /// let parser = Parser::new(config);
-    /// assert!(parser.parse("!ping should work").is_some());
-    /// assert!(parser.parse("!PiNg should also work").is_some());
-    /// ```
-    pub fn case_insensitive(mut self) -> Self {
-        self.case_sensitive = false;
-        self
-    }
-}
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum CaseSensitivity {
-    Insensitive(UniCase<String>),
-    Sensitive(String),
-}
-
-impl AsRef<str> for CaseSensitivity {
-    fn as_ref(&self) -> &str {
-        match self {
-            Self::Insensitive(u) => u.as_str(),
-            Self::Sensitive(s) => s.as_str(),
-        }
-    }
-}
-
-impl PartialEq<str> for CaseSensitivity {
-    fn eq(&self, other: &str) -> bool {
-        match self {
-            Self::Insensitive(u) => u == &UniCase::new(other),
-            Self::Sensitive(s) => s == other,
-        }
     }
 }
 

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -73,11 +73,15 @@
 #![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
 
 mod arguments;
+mod builder;
+mod casing;
 mod config;
 mod parser;
 
 pub use self::{
     arguments::Arguments,
-    config::{CaseSensitivity, CommandBuilder, Config},
+    builder::CommandBuilder,
+    casing::CaseSensitivity,
+    config::Config,
     parser::{Command, Parser},
 };


### PR DESCRIPTION
# Restructure of `command-parser`

This pr restructures the command parser into smaller modules.
This change is fully cosmetic, and the only non cosmetic change
is the internal visibility of some fields.

# Helper lint for `CommandBuilder`

This will make it so that it will error with an error like
the following if `add()` is not called on a command builder

```rust
warning: unused `dawn_command_parser::builder::command::CommandBuilder` that must be used
  --> src/main.rs:36:9
   |
36 |         config.command("today");
   |         ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_must_use)]` on by default
   = note: If `add` is not called the command will not be added.
```

This will make it harder to accidently forget to call it.