### PR TITLE
Update the id when resuming

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -198,7 +198,10 @@ impl ShardProcessor {
                     // it is some.
                     let (seq, id) = self.resume.take().unwrap();
                     warn!("Resumeing with ({}, {})!", seq, id);
-                    let payload = Resume::new(seq, id, self.config.token());
+                    let payload = Resume::new(seq, &id, self.config.token());
+
+                    // Set id so it is correct for next resume.
+                    self.session.set_id(id).await;
 
                     if *interval > 0 {
                         self.session.set_heartbeat_interval(*interval);


### PR DESCRIPTION
The id was not correctly updated when resuming so
resumes would fail every other time, when saying
update it should be added that it just updates it
to the value it had before the resume.

This closes #95

Signed-off-by: Valdemar Erk <valdemar@erk.io>