### PR TITLE
Made queues work with clusters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "gateway/examples/cluster",
     "gateway/examples/metrics",
     "gateway/examples/shard",
+    "gateway/examples/queue",
     "http",
     "http/examples/get-message",
     "http/examples/proxy",

--- a/gateway/examples/queue/Cargo.toml
+++ b/gateway/examples/queue/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+authors = ["Valdemar Erk <valdemar@erk.io>"]
+edition = "2018"
+name = "dawn-gateway-example-queue"
+version = "0.1.0"
+
+[dependencies]
+dawn-gateway = { path = "../.." }
+futures = "0.3"
+pretty_env_logger = "0.3"
+tokio = { version = "0.2", features = ["macros", "rt-core"] }
+async-trait = "0.1"

--- a/gateway/examples/queue/src/main.rs
+++ b/gateway/examples/queue/src/main.rs
@@ -1,0 +1,32 @@
+use async_trait::async_trait;
+use dawn_gateway::{queue::Queue, Shard, ShardConfig};
+use futures::StreamExt;
+use std::{env, error::Error, sync::Arc};
+
+#[derive(Debug)]
+struct BadQueue;
+
+#[async_trait]
+impl Queue for BadQueue {
+    // DISCLAIMER: THIS IS A VERY BAD QUEUE!
+    async fn request(&self) {}
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    pretty_env_logger::init_timed();
+
+    let token = env::var("DISCORD_TOKEN")?;
+    let config = ShardConfig::builder(&token).queue(Arc::new(Box::new(BadQueue)));
+
+    let shard = Shard::new(config).await?;
+    println!("Created shard");
+
+    let mut events = shard.events().await;
+
+    while let Some(event) = events.next().await {
+        println!("Event: {:?}", event.event_type());
+    }
+
+    Ok(())
+}

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -1,6 +1,8 @@
 use super::error::{Error, Result};
-use crate::shard::config::{Config as ShardConfig, ConfigBuilder as ShardConfigBuilder};
-use crate::queue::{LocalQueue, Queue};
+use crate::{
+    queue::{LocalQueue, Queue},
+    shard::config::{Config as ShardConfig, ConfigBuilder as ShardConfigBuilder},
+};
 use dawn_http::Client;
 use dawn_model::gateway::payload::update_status::UpdateStatusInfo;
 use std::{

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -2,9 +2,7 @@ use super::{
     config::{Config, ShardScheme},
     error::{Error, Result},
 };
-use crate::{
-    shard::{event::EventType, Config as ShardConfig, Event, Information, Shard},
-};
+use crate::shard::{event::EventType, Config as ShardConfig, Event, Information, Shard};
 use futures::{
     future,
     lock::Mutex,

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -243,12 +243,7 @@ impl Cluster {
 
         let shard = Shard::new(config).await.ok()?;
 
-        if let Some(old) = cluster
-            .shards
-            .lock()
-            .await
-            .insert(shard_id, shard.clone())
-        {
+        if let Some(old) = cluster.shards.lock().await.insert(shard_id, shard.clone()) {
             old.shutdown().await;
         }
 

--- a/gateway/src/queue.rs
+++ b/gateway/src/queue.rs
@@ -100,28 +100,3 @@ impl Queue for LocalQueue {
     }
     */
 }
-
-/*
-async fn queue_spawner(queue: Weak<LocalQueueRef>) -> Option<()> {
-    const DUR: Duration = Duration::from_secs(6);
-
-    while let Some(req) = queue.upgrade()?.requests.lock().await.pop_front() {
-        if let Err(()) = req.send(()) {
-            warn!("Request rx dropped before success");
-        } else {
-            info!("Successfully sent allowance");
-        }
-
-        tokio_timer::delay_for(DUR).await;
-    }
-
-    tokio_timer::delay_for(DUR).await;
-
-    queue
-        .upgrade()?
-        .task_running
-        .store(false, Ordering::Release);
-
-    Some(())
-}
-*/

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use super::{Error, Result};
 use crate::queue::{LocalQueue, Queue};
 use dawn_http::Client as HttpClient;
@@ -15,7 +16,7 @@ pub struct Config {
     http_client: HttpClient,
     large_threshold: u64,
     presence: Option<UpdateStatusInfo>,
-    pub(crate) queue: Box<dyn Queue + Send + Sync>,
+    pub(crate) queue: Arc<Box<dyn Queue>>,
     shard: [u64; 2],
     token: String,
 }
@@ -102,7 +103,7 @@ impl ConfigBuilder {
             http_client: HttpClient::new(token.clone()),
             large_threshold: 250,
             presence: None,
-            queue: Box::new(LocalQueue::new()),
+            queue: Arc::new(Box::new(LocalQueue::new())),
             shard: [0, 1],
             token,
         })
@@ -179,8 +180,8 @@ impl ConfigBuilder {
     /// all shards when ran by a [`Cluster`].
     ///
     /// [`Cluster`]: ../../cluster/struct.Cluster.html
-    pub fn queue(mut self, queue: impl Into<Box<dyn Queue + Send + Sync>>) -> Self {
-        self.0.queue = queue.into();
+    pub fn queue(mut self, queue: Arc<Box<dyn Queue>>) -> Self {
+        self.0.queue = queue;
 
         self
     }

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -1,8 +1,8 @@
-use std::sync::Arc;
 use super::{Error, Result};
 use crate::queue::{LocalQueue, Queue};
 use dawn_http::Client as HttpClient;
 use dawn_model::gateway::payload::update_status::UpdateStatusInfo;
+use std::sync::Arc;
 
 /// The configuration used by the shard to identify with the gateway and
 /// operate.

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -191,7 +191,7 @@ impl ShardProcessor {
             Hello(interval) => {
                 #[cfg(feature = "metrics")]
                 counter!("GatewayEvent", 1, "GatewayEvent" => "Hello");
-                warn!("[EVENT] Hello({})", interval);
+                debug!("[EVENT] Hello({})", interval);
 
                 if self.session.stage() == Stage::Resuming && self.resume.is_some() {
                     // Safe to unwrap so here as we have just checked that
@@ -249,7 +249,7 @@ impl ShardProcessor {
     }
 
     async fn reconnect(&mut self, full_reconnect: bool) {
-        warn!("[reconnect] Reconnection started!");
+        info!("[reconnect] Reconnection started!");
         loop {
             // Await allowance if doing a full reconnect
             if full_reconnect {
@@ -298,7 +298,7 @@ impl ShardProcessor {
     }
 
     async fn resume(&mut self) -> Result<()> {
-        warn!("[resume] Resume started!");
+        info!("[resume] Resume started!");
         self.session.set_stage(Stage::Resuming);
         self.session.stop_heartbeater().await;
 
@@ -325,7 +325,7 @@ impl ShardProcessor {
             Err(Error::PayloadSerialization {
                 source,
             }) => {
-                log::warn!("Failed to serialize message to send: {:?}", source);
+                warn!("Failed to serialize message to send: {:?}", source);
 
                 Err(Error::PayloadSerialization {
                     source,
@@ -334,8 +334,8 @@ impl ShardProcessor {
             Err(Error::SendingMessage {
                 source,
             }) => {
-                log::warn!("Failed to send message: {:?}", source);
-                log::info!("Reconnecting");
+                warn!("Failed to send message: {:?}", source);
+                info!("Reconnecting");
 
                 self.reconnect(true).await;
 

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -251,7 +251,10 @@ impl ShardProcessor {
     async fn reconnect(&mut self, full_reconnect: bool) {
         warn!("[reconnect] Reconnection started!");
         loop {
-            self.config.queue.request().await;
+            // Await allowance if doing a full reconnect
+            if full_reconnect {
+                self.config.queue.request().await;
+            }
 
             let new_stream = match connect::connect(&self.url).await {
                 Ok(s) => s,

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -10,7 +10,8 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::pub_enum_variant_names,
-    clippy::must_use_candidate
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc
 )]
 
 pub mod client;

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -72,7 +72,11 @@
     unused,
     warnings
 )]
-#![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::struct_excessive_bools
+)]
 
 pub mod channel;
 pub mod gateway;


### PR DESCRIPTION
Made the queue an Arc to make sure that all shards in a cluster use
the same queue.

Loosend a trait bound to make it easier to work with queues.
(fixes #101)

Also added a example with a very bad, but custom queue.

Also makes it so that it will only query the queue when doing a full reconnection.

Signed-off-by: Valdemar Erk <valdemar@erk.io>