### PR TITLE
Fix to UpdateStatus and INVITE_CREATE

### DIFF
--- a/model/src/gateway/payload/invite_create.rs
+++ b/model/src/gateway/payload/invite_create.rs
@@ -10,7 +10,7 @@ pub struct InviteCreate {
     pub code: String,
     pub created_at: String,
     pub guild_id: GuildId,
-    pub inviter: PartialUser,
+    pub inviter: Option<PartialUser>,
     pub max_age: u64,
     pub max_uses: u64,
     pub temporary: bool,
@@ -23,7 +23,7 @@ pub struct InviteCreate {
 )]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct PartialUser {
-    avatar: String,
+    avatar: Option<String>,
     discriminator: String,
     id: UserId,
     username: String,

--- a/model/src/gateway/payload/update_status.rs
+++ b/model/src/gateway/payload/update_status.rs
@@ -22,7 +22,7 @@ impl UpdateStatus {
     ) -> Self {
         Self {
             d: UpdateStatusInfo::new(afk, game, since, status),
-            op: OpCode::Identify,
+            op: OpCode::StatusUpdate,
         }
     }
 }


### PR DESCRIPTION
UpdateStatus was errorously sending a indentify instead of an status
update opcode.

INVITE_CREATE had some errors in the documentation, they have not yet
been fixed, but I have confirmation that this is correct.

Signed-off-by: Valdemar Erk <valdemar@erk.io>


----

OBS: This PR depends on https://github.com/dawn-rs/dawn/pull/103.

Note: This will probably ICE Clippy because of https://github.com/rust-lang/rust-clippy/issues/5238.