### PR TITLE
Add reason to all moderation endpoints.

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = "0.10"
 serde = "1"
 serde_json = "1"
 tokio = "0.2"
+percent-encoding = "2.1"
 
 [dev-dependencies]
 tokio = "0.2"

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -805,7 +805,7 @@ impl Client {
             });
         }
 
-        if resp.status().is_client_error() {
+        if resp.status().is_server_error() {
             return Err(Error::Response {
                 source: ResponseError::Server {
                     response: resp,

--- a/http/src/request/channel/delete_channel.rs
+++ b/http/src/request/channel/delete_channel.rs
@@ -5,6 +5,7 @@ pub struct DeleteChannel<'a> {
     channel_id: ChannelId,
     fut: Option<Pending<'a, Channel>>,
     http: &'a Client,
+    reason: Option<String>,
 }
 
 impl<'a> DeleteChannel<'a> {
@@ -13,15 +14,32 @@ impl<'a> DeleteChannel<'a> {
             channel_id,
             fut: None,
             http,
+            reason: None,
         }
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::DeleteChannel {
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                headers,
+                Route::DeleteChannel {
+                    channel_id: self.channel_id.0,
+                },
+            ))
+        } else {
+            Request::from(Route::DeleteChannel {
                 channel_id: self.channel_id.0,
-            },
-        ))));
+            })
+        };
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/delete_channel_permission.rs
+++ b/http/src/request/channel/delete_channel_permission.rs
@@ -6,6 +6,7 @@ pub struct DeleteChannelPermission<'a> {
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     target_id: u64,
+    reason: Option<String>,
 }
 
 impl<'a> DeleteChannelPermission<'a> {
@@ -15,16 +16,34 @@ impl<'a> DeleteChannelPermission<'a> {
             fut: None,
             http,
             target_id,
+            reason: None,
         }
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::DeletePermissionOverwrite {
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                headers,
+                Route::DeletePermissionOverwrite {
+                    channel_id: self.channel_id.0,
+                    target_id: self.target_id,
+                },
+            ))
+        } else {
+            Request::from(Route::DeletePermissionOverwrite {
                 channel_id: self.channel_id.0,
                 target_id: self.target_id,
-            },
-        ))));
+            })
+        };
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/delete_pin.rs
+++ b/http/src/request/channel/delete_pin.rs
@@ -6,6 +6,7 @@ pub struct DeletePin<'a> {
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     message_id: MessageId,
+    reason: Option<String>,
 }
 
 impl<'a> DeletePin<'a> {
@@ -15,16 +16,34 @@ impl<'a> DeletePin<'a> {
             fut: None,
             http,
             message_id,
+            reason: None,
         }
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::UnpinMessage {
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                headers,
+                Route::UnpinMessage {
+                    channel_id: self.channel_id.0,
+                    message_id: self.message_id.0,
+                },
+            ))
+        } else {
+            Request::from(Route::UnpinMessage {
                 channel_id: self.channel_id.0,
                 message_id: self.message_id.0,
-            },
-        ))));
+            })
+        };
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -19,6 +19,7 @@ pub struct CreateInvite<'a> {
     fields: CreateInviteFields,
     fut: Option<Pending<'a, Invite>>,
     http: &'a Client,
+    reason: Option<String>,
 }
 
 impl<'a> CreateInvite<'a> {
@@ -28,6 +29,7 @@ impl<'a> CreateInvite<'a> {
             fields: CreateInviteFields::default(),
             fut: None,
             http,
+            reason: None,
         }
     }
 
@@ -67,13 +69,32 @@ impl<'a> CreateInvite<'a> {
         self
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(&self.fields)?,
-            Route::CreateInvite {
-                channel_id: self.channel_id.0,
-            },
-        )))));
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                headers,
+                Route::CreateInvite {
+                    channel_id: self.channel_id.0,
+                },
+            ))
+        } else {
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                Route::CreateInvite {
+                    channel_id: self.channel_id.0,
+                },
+            ))
+        };
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/message/delete_message.rs
+++ b/http/src/request/channel/message/delete_message.rs
@@ -6,6 +6,7 @@ pub struct DeleteMessage<'a> {
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     message_id: MessageId,
+    reason: Option<String>,
 }
 
 impl<'a> DeleteMessage<'a> {
@@ -15,16 +16,34 @@ impl<'a> DeleteMessage<'a> {
             fut: None,
             http,
             message_id,
+            reason: None,
         }
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::DeleteMessage {
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                headers,
+                Route::DeleteMessage {
+                    channel_id: self.channel_id.0,
+                    message_id: self.message_id.0,
+                },
+            ))
+        } else {
+            Request::from(Route::DeleteMessage {
                 channel_id: self.channel_id.0,
                 message_id: self.message_id.0,
-            },
-        ))));
+            })
+        };
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -22,6 +22,7 @@ pub struct UpdateChannel<'a> {
     fields: UpdateChannelFields,
     fut: Option<Pending<'a, Channel>>,
     http: &'a Client,
+    reason: Option<String>,
 }
 
 impl<'a> UpdateChannel<'a> {
@@ -31,6 +32,7 @@ impl<'a> UpdateChannel<'a> {
             fields: UpdateChannelFields::default(),
             fut: None,
             http,
+            reason: None,
         }
     }
 
@@ -93,13 +95,32 @@ impl<'a> UpdateChannel<'a> {
         self
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(&self.fields)?,
-            Route::UpdateChannel {
-                channel_id: self.channel_id.0,
-            },
-        )))));
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                headers,
+                Route::UpdateChannel {
+                    channel_id: self.channel_id.0,
+                },
+            ))
+        } else {
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                Route::UpdateChannel {
+                    channel_id: self.channel_id.0,
+                },
+            ))
+        };
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -24,6 +24,7 @@ pub struct CreateGuildChannel<'a> {
     fut: Option<Pending<'a, GuildChannel>>,
     guild_id: GuildId,
     http: &'a Client,
+    reason: Option<String>,
 }
 
 impl<'a> CreateGuildChannel<'a> {
@@ -44,6 +45,7 @@ impl<'a> CreateGuildChannel<'a> {
             fut: None,
             guild_id,
             http,
+            reason: None,
         }
     }
 
@@ -106,13 +108,32 @@ impl<'a> CreateGuildChannel<'a> {
         self
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(&self.fields)?,
-            Route::CreateChannel {
-                guild_id: self.guild_id.0,
-            },
-        )))));
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                headers,
+                Route::CreateChannel {
+                    guild_id: self.guild_id.0,
+                },
+            ))
+        } else {
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                Route::CreateChannel {
+                    guild_id: self.guild_id.0,
+                },
+            ))
+        };
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -16,6 +16,7 @@ pub struct CreateEmoji<'a> {
     fields: CreateEmojiFields,
     guild_id: GuildId,
     http: &'a Client,
+    reason: Option<String>,
 }
 
 impl<'a> CreateEmoji<'a> {
@@ -34,6 +35,7 @@ impl<'a> CreateEmoji<'a> {
             fut: None,
             guild_id,
             http,
+            reason: None,
         }
     }
 
@@ -43,13 +45,32 @@ impl<'a> CreateEmoji<'a> {
         self
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(&self.fields)?,
-            Route::CreateEmoji {
-                guild_id: self.guild_id.0,
-            },
-        )))));
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                headers,
+                Route::CreateEmoji {
+                    guild_id: self.guild_id.0,
+                },
+            ))
+        } else {
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                Route::CreateEmoji {
+                    guild_id: self.guild_id.0,
+                },
+            ))
+        };
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/emoji/delete_emoji.rs
+++ b/http/src/request/guild/emoji/delete_emoji.rs
@@ -6,6 +6,7 @@ pub struct DeleteEmoji<'a> {
     fut: Option<Pending<'a, ()>>,
     guild_id: GuildId,
     http: &'a Client,
+    reason: Option<String>,
 }
 
 impl<'a> DeleteEmoji<'a> {
@@ -15,16 +16,34 @@ impl<'a> DeleteEmoji<'a> {
             fut: None,
             guild_id,
             http,
+            reason: None,
         }
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::DeleteEmoji {
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                headers,
+                Route::DeleteEmoji {
+                    emoji_id: self.emoji_id.0,
+                    guild_id: self.guild_id.0,
+                },
+            ))
+        } else {
+            Request::from(Route::DeleteEmoji {
                 emoji_id: self.emoji_id.0,
                 guild_id: self.guild_id.0,
-            },
-        ))));
+            })
+        };
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -16,6 +16,7 @@ pub struct UpdateEmoji<'a> {
     fut: Option<Pending<'a, Emoji>>,
     guild_id: GuildId,
     http: &'a Client,
+    reason: Option<String>,
 }
 
 impl<'a> UpdateEmoji<'a> {
@@ -26,6 +27,7 @@ impl<'a> UpdateEmoji<'a> {
             fut: None,
             guild_id,
             http,
+            reason: None,
         }
     }
 
@@ -41,14 +43,34 @@ impl<'a> UpdateEmoji<'a> {
         self
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(&self.fields)?,
-            Route::UpdateEmoji {
-                emoji_id: self.emoji_id.0,
-                guild_id: self.guild_id.0,
-            },
-        )))));
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                headers,
+                Route::UpdateEmoji {
+                    emoji_id: self.emoji_id.0,
+                    guild_id: self.guild_id.0,
+                },
+            ))
+        } else {
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                Route::UpdateEmoji {
+                    emoji_id: self.emoji_id.0,
+                    guild_id: self.guild_id.0,
+                },
+            ))
+        };
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/integration/create_guild_integration.rs
+++ b/http/src/request/guild/integration/create_guild_integration.rs
@@ -13,6 +13,7 @@ pub struct CreateGuildIntegration<'a> {
     fut: Option<Pending<'a, ()>>,
     guild_id: GuildId,
     http: &'a Client,
+    reason: Option<String>,
 }
 
 impl<'a> CreateGuildIntegration<'a> {
@@ -30,16 +31,36 @@ impl<'a> CreateGuildIntegration<'a> {
             fut: None,
             guild_id,
             http,
+            reason: None,
         }
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(&self.fields)?,
-            Route::CreateGuildIntegration {
-                guild_id: self.guild_id.0,
-            },
-        )))));
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                headers,
+                Route::CreateGuildIntegration {
+                    guild_id: self.guild_id.0,
+                },
+            ))
+        } else {
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                Route::CreateGuildIntegration {
+                    guild_id: self.guild_id.0,
+                },
+            ))
+        };
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/integration/delete_guild_integration.rs
+++ b/http/src/request/guild/integration/delete_guild_integration.rs
@@ -6,6 +6,7 @@ pub struct DeleteGuildIntegration<'a> {
     guild_id: GuildId,
     http: &'a Client,
     integration_id: IntegrationId,
+    reason: Option<String>,
 }
 
 impl<'a> DeleteGuildIntegration<'a> {
@@ -15,16 +16,34 @@ impl<'a> DeleteGuildIntegration<'a> {
             guild_id,
             http,
             integration_id,
+            reason: None,
         }
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::DeleteGuildIntegration {
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                headers,
+                Route::DeleteGuildIntegration {
+                    guild_id: self.guild_id.0,
+                    integration_id: self.integration_id.0,
+                },
+            ))
+        } else {
+            Request::from(Route::DeleteGuildIntegration {
                 guild_id: self.guild_id.0,
                 integration_id: self.integration_id.0,
-            },
-        ))));
+            })
+        };
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/member/add_role_to_member.rs
+++ b/http/src/request/guild/member/add_role_to_member.rs
@@ -7,6 +7,7 @@ pub struct AddRoleToMember<'a> {
     http: &'a Client,
     role_id: RoleId,
     user_id: UserId,
+    reason: Option<String>,
 }
 
 impl<'a> AddRoleToMember<'a> {
@@ -22,17 +23,36 @@ impl<'a> AddRoleToMember<'a> {
             http,
             role_id: role_id.into(),
             user_id: user_id.into(),
+            reason: None,
         }
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::AddMemberRole {
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                headers,
+                Route::AddMemberRole {
+                    guild_id: self.guild_id.0,
+                    role_id: self.role_id.0,
+                    user_id: self.user_id.0,
+                },
+            ))
+        } else {
+            Request::from(Route::AddMemberRole {
                 guild_id: self.guild_id.0,
                 role_id: self.role_id.0,
                 user_id: self.user_id.0,
-            },
-        ))));
+            })
+        };
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/member/remove_member.rs
+++ b/http/src/request/guild/member/remove_member.rs
@@ -6,6 +6,7 @@ pub struct RemoveMember<'a> {
     guild_id: GuildId,
     http: &'a Client,
     user_id: UserId,
+    reason: Option<String>,
 }
 
 impl<'a> RemoveMember<'a> {
@@ -15,16 +16,34 @@ impl<'a> RemoveMember<'a> {
             guild_id,
             http,
             user_id,
+            reason: None,
         }
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::RemoveMember {
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                headers,
+                Route::RemoveMember {
+                    guild_id: self.guild_id.0,
+                    user_id: self.user_id.0,
+                },
+            ))
+        } else {
+            Request::from(Route::RemoveMember {
                 guild_id: self.guild_id.0,
                 user_id: self.user_id.0,
-            },
-        ))));
+            })
+        };
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/member/remove_role_from_member.rs
+++ b/http/src/request/guild/member/remove_role_from_member.rs
@@ -7,6 +7,7 @@ pub struct RemoveRoleFromMember<'a> {
     http: &'a Client,
     role_id: RoleId,
     user_id: UserId,
+    reason: Option<String>,
 }
 
 impl<'a> RemoveRoleFromMember<'a> {
@@ -22,17 +23,36 @@ impl<'a> RemoveRoleFromMember<'a> {
             http,
             role_id: role_id.into(),
             user_id: user_id.into(),
+            reason: None,
         }
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::RemoveMemberRole {
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                headers,
+                Route::RemoveMemberRole {
+                    guild_id: self.guild_id.0,
+                    role_id: self.role_id.0,
+                    user_id: self.user_id.0,
+                },
+            ))
+        } else {
+            Request::from(Route::RemoveMemberRole {
                 guild_id: self.guild_id.0,
                 role_id: self.role_id.0,
                 user_id: self.user_id.0,
-            },
-        ))));
+            })
+        };
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -18,6 +18,7 @@ pub struct CreateRole<'a> {
     fut: Option<Pending<'a, Role>>,
     guild_id: GuildId,
     http: &'a Client,
+    reason: Option<String>,
 }
 
 impl<'a> CreateRole<'a> {
@@ -27,6 +28,7 @@ impl<'a> CreateRole<'a> {
             fut: None,
             guild_id,
             http,
+            reason: None,
         }
     }
 
@@ -60,13 +62,32 @@ impl<'a> CreateRole<'a> {
         self
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(&self.fields)?,
-            Route::CreateRole {
-                guild_id: self.guild_id.0,
-            },
-        )))));
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                headers,
+                Route::CreateRole {
+                    guild_id: self.guild_id.0,
+                },
+            ))
+        } else {
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                Route::CreateRole {
+                    guild_id: self.guild_id.0,
+                },
+            ))
+        };
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/role/delete_role.rs
+++ b/http/src/request/guild/role/delete_role.rs
@@ -6,6 +6,7 @@ pub struct DeleteRole<'a> {
     guild_id: GuildId,
     http: &'a Client,
     role_id: RoleId,
+    reason: Option<String>,
 }
 
 impl<'a> DeleteRole<'a> {
@@ -15,16 +16,34 @@ impl<'a> DeleteRole<'a> {
             guild_id,
             http,
             role_id,
+            reason: None,
         }
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::DeleteRole {
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                headers,
+                Route::DeleteRole {
+                    guild_id: self.guild_id.0,
+                    role_id: self.role_id.0,
+                },
+            ))
+        } else {
+            Request::from(Route::DeleteRole {
                 guild_id: self.guild_id.0,
                 role_id: self.role_id.0,
-            },
-        ))));
+            })
+        };
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -19,6 +19,7 @@ pub struct UpdateRole<'a> {
     guild_id: GuildId,
     http: &'a Client,
     role_id: RoleId,
+    reason: Option<String>,
 }
 
 impl<'a> UpdateRole<'a> {
@@ -29,6 +30,7 @@ impl<'a> UpdateRole<'a> {
             guild_id,
             http,
             role_id,
+            reason: None,
         }
     }
 
@@ -62,14 +64,34 @@ impl<'a> UpdateRole<'a> {
         self
     }
 
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            serde_json::to_vec(&self.fields)?,
-            Route::UpdateRole {
-                guild_id: self.guild_id.0,
-                role_id: self.role_id.0,
-            },
-        )))));
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                headers,
+                Route::UpdateRole {
+                    guild_id: self.guild_id.0,
+                    role_id: self.role_id.0,
+                },
+            ))
+        } else {
+            Request::from((
+                serde_json::to_vec(&self.fields)?,
+                Route::UpdateRole {
+                    guild_id: self.guild_id.0,
+                    role_id: self.role_id.0,
+                },
+            ))
+        };
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/prelude.rs
+++ b/http/src/request/prelude.rs
@@ -1,3 +1,4 @@
+pub(super) use super::{audit_header, Pending, Request};
 pub use super::{
     channel::{invite::*, message::*, reaction::*, webhook::*, *},
     get_gateway::GetGateway,
@@ -6,6 +7,5 @@ pub use super::{
     guild::{ban::*, emoji::*, integration::*, member::*, role::*, *},
     user::*,
 };
-pub(super) use super::{Pending, Request};
 pub(super) use crate::{client::Client, error::Result, routing::Route};
 pub(super) use serde::Serialize;

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -520,14 +520,17 @@ impl Route {
                 reason,
                 user_id,
             } => {
-                let mut path = format!("guilds/{}/bans/{}", guild_id, user_id);
+                let mut path = format!("guilds/{}/bans/{}?", guild_id, user_id);
 
                 if let Some(delete_message_days) = delete_message_days {
                     let _ = write!(path, "delete-message-days={}", delete_message_days);
+                    if reason.is_some() {
+                        let _ = write!(path, "&");
+                    }
                 }
 
                 if let Some(reason) = reason {
-                    let _ = write!(path, "&reason={}", reason);
+                    let _ = write!(path, "reason={}", reason);
                 }
 
                 (Method::PUT, Path::GuildsIdBansUserId(guild_id), path.into())


### PR DESCRIPTION
This pr adds reason to all moderation endpoints. [0]

----

It also fixes it so server errors are actually server errors.

---

Note: The create ban, does not have an additionel reason command as it gets overwritten by the one already there.

---

[0]: https://discordapp.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events