### PR TITLE
Add support for allowed mentions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "gateway/examples/shard",
     "gateway/examples/queue",
     "http",
+    "http/examples/allowed-mentions",
     "http/examples/get-message",
     "http/examples/proxy",
     "model",

--- a/http/examples/allowed-mentions/Cargo.toml
+++ b/http/examples/allowed-mentions/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+authors = ["Valdemar Erk <valdemar@erk.io>"]
+edition = "2018"
+name = "dawn-http-example-allowed-mentions"
+publish = false
+version = "0.0.1"
+
+[dependencies]
+dawn-http = { path = "../.." }
+dawn-model = { path = "../../../model" }
+pretty_env_logger = "0.3"
+tokio = { version = "0.2", features = ["macros", "rt-core"] }

--- a/http/examples/allowed-mentions/src/main.rs
+++ b/http/examples/allowed-mentions/src/main.rs
@@ -1,0 +1,22 @@
+use dawn_http::Client;
+use dawn_model::id::{ChannelId, UserId};
+use std::{env, error::Error};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    pretty_env_logger::init_timed();
+
+    let client = Client::new(env::var("DISCORD_TOKEN")?);
+    let channel_id = ChannelId(381_926_291_785_383_946);
+    let user_id = UserId(77_469_400_222_932_992);
+
+    client
+        .create_message(channel_id)
+        .content(format!("Hi <@{}>", user_id.0))
+        .allowed_mentions()
+        .parse_specific_users(vec![user_id])
+        .build()
+        .await?;
+
+    Ok(())
+}

--- a/http/src/request/channel/message/allowed_mentions.rs
+++ b/http/src/request/channel/message/allowed_mentions.rs
@@ -1,0 +1,196 @@
+use super::CreateMessage;
+use dawn_model::id::{RoleId, UserId};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Parsed;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ExplicitUser(Vec<UserId>);
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ExplicitRole(Vec<RoleId>);
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Unspecified;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ParseTypes {
+    Users,
+    Roles,
+    Everyone,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Clone, Default, Debug, Eq, Hash, PartialEq)]
+#[must_use = "It will not be added unless `build()` is called."]
+pub struct AllowedMentions {
+    parse: Vec<ParseTypes>,
+    users: Option<Vec<UserId>>,
+    roles: Option<Vec<RoleId>>,
+}
+
+pub trait VisitAllowedMentionsEveryone: Sized {
+    fn visit(self, _: &mut AllowedMentions) {}
+}
+
+pub trait VisitAllowedMentionsUsers: Sized {
+    fn visit(self, _: &mut AllowedMentions) {}
+}
+
+pub trait VisitAllowedMentionsRoles: Sized {
+    fn visit(self, _: &mut AllowedMentions) {}
+}
+
+impl VisitAllowedMentionsEveryone for Unspecified {}
+impl VisitAllowedMentionsUsers for Unspecified {}
+impl VisitAllowedMentionsRoles for Unspecified {}
+
+impl VisitAllowedMentionsEveryone for Parsed {
+    fn visit(self, d: &mut AllowedMentions) {
+        d.parse.push(ParseTypes::Everyone);
+    }
+}
+
+impl VisitAllowedMentionsUsers for Parsed {
+    fn visit(self, d: &mut AllowedMentions) {
+        d.parse.push(ParseTypes::Users);
+    }
+}
+
+impl VisitAllowedMentionsRoles for Parsed {
+    fn visit(self, d: &mut AllowedMentions) {
+        d.parse.push(ParseTypes::Roles);
+    }
+}
+
+impl VisitAllowedMentionsUsers for ExplicitUser {
+    fn visit(self, d: &mut AllowedMentions) {
+        d.users = Some(self.0)
+    }
+}
+
+impl VisitAllowedMentionsRoles for ExplicitRole {
+    fn visit(self, d: &mut AllowedMentions) {
+        d.roles = Some(self.0)
+    }
+}
+
+pub struct AllowedMentionsBuilder<'a, E, U, R> {
+    create_message: CreateMessage<'a>,
+    e: E,
+    u: U,
+    r: R,
+}
+
+impl<'a> AllowedMentionsBuilder<'a, Unspecified, Unspecified, Unspecified> {
+    pub(crate) fn new(create_message: CreateMessage<'a>) -> Self {
+        Self {
+            create_message,
+            e: Unspecified,
+            u: Unspecified,
+            r: Unspecified,
+        }
+    }
+}
+
+impl<'a, U, R> AllowedMentionsBuilder<'a, Unspecified, U, R> {
+    pub fn parse_everyone(self) -> AllowedMentionsBuilder<'a, Parsed, U, R> {
+        AllowedMentionsBuilder {
+            create_message: self.create_message,
+            e: Parsed,
+            u: self.u,
+            r: self.r,
+        }
+    }
+}
+
+impl<'a, E, R> AllowedMentionsBuilder<'a, E, Unspecified, R> {
+    pub fn parse_users(self) -> AllowedMentionsBuilder<'a, E, Parsed, R> {
+        AllowedMentionsBuilder {
+            create_message: self.create_message,
+            e: self.e,
+            u: Parsed,
+            r: self.r,
+        }
+    }
+
+    pub fn parse_specific_users(
+        self,
+        u: impl IntoIterator<Item = UserId>,
+    ) -> AllowedMentionsBuilder<'a, E, ExplicitUser, R> {
+        let vec = u.into_iter().collect::<Vec<_>>();
+        AllowedMentionsBuilder {
+            create_message: self.create_message,
+            e: self.e,
+            u: ExplicitUser(vec),
+            r: self.r,
+        }
+    }
+}
+
+impl<'a, E, U> AllowedMentionsBuilder<'a, E, U, Unspecified> {
+    pub fn parse_roles(self) -> AllowedMentionsBuilder<'a, E, U, Parsed> {
+        AllowedMentionsBuilder {
+            create_message: self.create_message,
+            e: self.e,
+            u: self.u,
+            r: Parsed,
+        }
+    }
+
+    pub fn parse_specific_roles(
+        self,
+        r: impl IntoIterator<Item = RoleId>,
+    ) -> AllowedMentionsBuilder<'a, E, U, ExplicitRole> {
+        let vec = r.into_iter().collect::<Vec<_>>();
+        AllowedMentionsBuilder {
+            create_message: self.create_message,
+            e: self.e,
+            u: self.u,
+            r: ExplicitRole(vec),
+        }
+    }
+}
+
+impl<'a, E, U> AllowedMentionsBuilder<'a, E, U, ExplicitRole> {
+    pub fn parse_specific_roles(mut self, r: impl IntoIterator<Item = RoleId>) -> Self {
+        self.r.0.extend(r);
+        AllowedMentionsBuilder {
+            create_message: self.create_message,
+            e: self.e,
+            u: self.u,
+            r: self.r,
+        }
+    }
+}
+
+impl<'a, E, R> AllowedMentionsBuilder<'a, E, ExplicitUser, R> {
+    pub fn parse_specific_users(mut self, u: impl IntoIterator<Item = UserId>) -> Self {
+        self.u.0.extend(u);
+        AllowedMentionsBuilder {
+            create_message: self.create_message,
+            e: self.e,
+            u: self.u,
+            r: self.r,
+        }
+    }
+}
+
+impl<
+        'a,
+        E: VisitAllowedMentionsEveryone,
+        U: VisitAllowedMentionsUsers,
+        R: VisitAllowedMentionsRoles,
+    > AllowedMentionsBuilder<'a, E, U, R>
+{
+    pub fn build(mut self) -> CreateMessage<'a> {
+        let mut m = AllowedMentions::default();
+
+        self.e.visit(&mut m);
+        self.u.visit(&mut m);
+        self.r.visit(&mut m);
+
+        self.create_message.fields.allowed_mentions.replace(m);
+        self.create_message
+    }
+}

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -1,3 +1,4 @@
+use super::allowed_mentions::{AllowedMentions, AllowedMentionsBuilder, Unspecified};
 use crate::request::prelude::*;
 use dawn_model::{
     channel::{embed::Embed, Message},
@@ -10,18 +11,19 @@ use reqwest::{
 use std::collections::HashMap;
 
 #[derive(Default, Serialize)]
-struct CreateMessageFields {
+pub(crate) struct CreateMessageFields {
     content: Option<String>,
     embed: Option<Embed>,
     nonce: Option<u64>,
     payload_json: Option<Vec<u8>>,
     tts: Option<bool>,
+    pub(crate) allowed_mentions: Option<AllowedMentions>,
 }
 
 pub struct CreateMessage<'a> {
     attachments: HashMap<String, Body>,
     channel_id: ChannelId,
-    fields: CreateMessageFields,
+    pub(crate) fields: CreateMessageFields,
     fut: Option<Pending<'a, Message>>,
     http: &'a Client,
 }
@@ -47,6 +49,12 @@ impl<'a> CreateMessage<'a> {
         self.fields.embed.replace(embed);
 
         self
+    }
+
+    pub fn allowed_mentions(
+        self,
+    ) -> AllowedMentionsBuilder<'a, Unspecified, Unspecified, Unspecified> {
+        AllowedMentionsBuilder::new(self)
     }
 
     pub fn attachment(mut self, name: impl Into<String>, file: impl Into<Body>) -> Self {

--- a/http/src/request/channel/message/mod.rs
+++ b/http/src/request/channel/message/mod.rs
@@ -1,3 +1,4 @@
+pub mod allowed_mentions;
 mod create_message;
 mod delete_message;
 mod delete_messages;


### PR DESCRIPTION
It uses a builder that will make sure that it is
always valid at compile time. So you cannot for example
make it parse all users, and then afterwards parse specific
users.

Closes #113 

Thanks to @jhgg for the inspiration to the builder.

Signed-off-by: Valdemar Erk <valdemar@erk.io>