### PR TITLE
More ergonomic attachment handling for CreateMessage

### DIFF
--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -13,7 +13,6 @@ use std::collections::HashMap;
 struct CreateMessageFields {
     content: Option<String>,
     embed: Option<Embed>,
-    file: Option<Vec<u8>>,
     nonce: Option<u64>,
     payload_json: Option<Vec<u8>>,
     tts: Option<bool>,
@@ -46,12 +45,6 @@ impl<'a> CreateMessage<'a> {
 
     pub fn embed(mut self, embed: Embed) -> Self {
         self.fields.embed.replace(embed);
-
-        self
-    }
-
-    pub fn file(mut self, file: impl Into<Vec<u8>>) -> Self {
-        self.fields.file.replace(file.into());
 
         self
     }


### PR DESCRIPTION
Only the second commit is a breaking change. Since Body implements `Into<Vec<u8>>` we simply increased the surface of accepted attachments 

Also I left the `payload_json` as `Vec<u8>` because that's likely to come from serde as a `Vec<u8>` and I personally don't see any use for setting that ever anyway