### PR TITLE
Make the queue trait more specific and support for large sharding.

### DIFF
--- a/gateway/examples/queue/src/main.rs
+++ b/gateway/examples/queue/src/main.rs
@@ -9,7 +9,7 @@ struct BadQueue;
 #[async_trait]
 impl Queue for BadQueue {
     // DISCLAIMER: THIS IS A VERY BAD QUEUE!
-    async fn request(&self) {}
+    async fn request(&self, _shard_id: [u64; 2]) {}
 }
 
 #[tokio::main]

--- a/gateway/src/queue.rs
+++ b/gateway/src/queue.rs
@@ -89,8 +89,7 @@ impl Queue for LocalQueue {
     /// Request to be able to identify with the gateway. This will place this
     /// request behind all other requests, and the returned future will resolve
     /// once the request has been completed.
-    #[allow(clippy::used_underscore_binding)] // Needed for some reason, possible a bug.
-    async fn request(&self, _shard_id: [u64; 2]) {
+    async fn request(&self, _: [u64; 2]) {
         let (tx, rx) = oneshot::channel();
 
         if let Err(err) = self.0.clone().send(tx).await {

--- a/gateway/src/queue.rs
+++ b/gateway/src/queue.rs
@@ -1,4 +1,10 @@
+mod day_limiter;
+mod large_bot_queue;
+
+pub use large_bot_queue::LargeBotQueue;
+
 use async_trait::async_trait;
+use day_limiter::DayLimiter;
 use futures::{
     channel::{
         mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
@@ -13,8 +19,7 @@ use std::{fmt::Debug, time::Duration};
 
 #[async_trait]
 pub trait Queue: Debug + Send + Sync {
-    async fn request(&self);
-    //async fn is_running(&self) -> bool;
+    async fn request(&self, shard_id: [u64; 2]);
 }
 
 /// A local, in-process implementation of a [`Queue`] which manages the
@@ -35,9 +40,13 @@ pub trait Queue: Debug + Send + Sync {
 /// not** use this implementation. Shards across multiple processes may
 /// create new sessions at the same time, which is bad.
 ///
+/// It should also not be used for very large sharding, for that the
+/// [`LargeBotQueue`] can be used.
+///
 /// If you can't use this, look into an alternative implementation of the
 /// [`Queue`], such as the [`gateway-queue`] broker.
 ///
+/// [`LargeBotQueue`]: ./queue/struct.LargeBotQueue.html
 /// [`Cluster`]: ../cluster/struct.Cluster.html
 /// [`Shard`]: ../shard/struct.Shard.html
 /// [`gateway-queue`]: https://github.com/dawn-rs/gateway-queue
@@ -64,13 +73,14 @@ impl LocalQueue {
 }
 
 async fn waiter(mut rx: UnboundedReceiver<Sender<()>>) {
-    const DUR: Duration = Duration::from_secs(6);
+    const DUR: Duration = Duration::from_secs(5);
+    let mut ticker = tokio::time::interval(DUR);
     while let Some(req) = rx.next().await {
+        ticker.tick().await;
         if let Err(err) = req.send(()) {
             warn!("[LocalQueue/waiter] send failed with: {:?}, skipping", err);
             continue;
         }
-        tokio::time::delay_for(DUR).await;
     }
 }
 
@@ -79,7 +89,8 @@ impl Queue for LocalQueue {
     /// Request to be able to identify with the gateway. This will place this
     /// request behind all other requests, and the returned future will resolve
     /// once the request has been completed.
-    async fn request(&self) {
+    #[allow(clippy::used_underscore_binding)] // Needed for some reason, possible a bug.
+    async fn request(&self, _shard_id: [u64; 2]) {
         let (tx, rx) = oneshot::channel();
 
         if let Err(err) = self.0.clone().send(tx).await {
@@ -87,16 +98,8 @@ impl Queue for LocalQueue {
             return;
         }
 
-        warn!("Waiting for allowance!");
+        info!("Waiting for allowance!");
 
         let _ = rx.await;
     }
-    /*
-    /// Whether the queue is actively going through requests.
-    ///
-    /// Once all requests have been completed, this will return `false`.
-    async fn is_running(&self) -> bool {
-        self.0.task_running.load(Ordering::Relaxed)
-    }
-    */
 }

--- a/gateway/src/queue/day_limiter.rs
+++ b/gateway/src/queue/day_limiter.rs
@@ -1,0 +1,65 @@
+use crate::shard::error::{Error, Result};
+
+use tokio::time::delay_until;
+
+use std::time::Duration;
+
+use log::warn;
+use tokio::{sync::Mutex, time::Instant};
+
+#[derive(Debug)]
+pub(crate) struct DayLimiter(Mutex<DayLimiterInner>);
+
+#[derive(Debug)]
+pub(crate) struct DayLimiterInner {
+    pub http: dawn_http::Client,
+    pub next_reset: Instant,
+    pub total: u64,
+    pub current: u64,
+}
+
+impl DayLimiter {
+    pub async fn new(http: &dawn_http::Client) -> Result<Self> {
+        let info = http
+            .gateway()
+            .authed()
+            .await
+            .map_err(|e| Error::GettingGatewayUrl {
+                source: e,
+            })?;
+        let next_reset = Instant::now() + Duration::from_millis(info.session_start_limit.remaining);
+        let total = info.session_start_limit.total;
+        let remaining = info.session_start_limit.remaining;
+        assert!(total >= remaining);
+        let current = total - remaining;
+        Ok(DayLimiter(Mutex::new(DayLimiterInner {
+            http: http.clone(),
+            next_reset,
+            total: info.session_start_limit.total,
+            current,
+        })))
+    }
+
+    pub async fn get(&self) {
+        let mut lock = self.0.lock().await;
+        if lock.current < lock.total {
+            lock.current += 1;
+        } else {
+            let wait = lock.next_reset;
+            delay_until(wait).await;
+            if let Ok(info) = lock.http.gateway().authed().await {
+                let next_reset =
+                    Instant::now() + Duration::from_millis(info.session_start_limit.remaining);
+                let total = info.session_start_limit.total;
+                let remaining = info.session_start_limit.remaining;
+                assert!(total >= remaining);
+                let current = total - remaining;
+                lock.next_reset = next_reset;
+                lock.total = total;
+                lock.current = current + 1;
+            } else {
+                warn!("Unable to get new session limits, skipping it. (This may cause bad things)")
+            }
+        }
+    }
+}

--- a/gateway/src/queue/large_bot_queue.rs
+++ b/gateway/src/queue/large_bot_queue.rs
@@ -66,7 +66,7 @@ impl Queue for LargeBotQueue {
     /// once the request has been completed.
     async fn request(&self, shard_id: [u64; 2]) {
         #[allow(clippy::cast_possible_truncation)]
-        let bucket = (shard_id[0] % 16) as usize;
+        let bucket = (shard_id[0] % (self.buckets.len() as u64)) as usize;
         let (tx, rx) = oneshot::channel();
 
         self.limiter.get().await;

--- a/gateway/src/queue/large_bot_queue.rs
+++ b/gateway/src/queue/large_bot_queue.rs
@@ -38,7 +38,7 @@ impl LargeBotQueue {
             buckets: queues,
             limiter: DayLimiter::new(http).await.expect(
                 "Getting the first session limits failed, \
-                                                         Is network connection aviable",
+                 Is network connection available",
             ),
         }
     }

--- a/gateway/src/queue/large_bot_queue.rs
+++ b/gateway/src/queue/large_bot_queue.rs
@@ -1,0 +1,82 @@
+use super::{DayLimiter, Queue};
+use async_trait::async_trait;
+use futures::{
+    channel::{
+        mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
+        oneshot::{self, Sender},
+    },
+    sink::SinkExt,
+    stream::StreamExt,
+};
+use log::{info, warn};
+use std::{fmt::Debug, time::Duration};
+
+/// Large bot queue is for bots that are marked as very large by Discord.
+///
+/// Usage with other bots will end up getting a large amount of failed identifies.
+#[derive(Debug)]
+pub struct LargeBotQueue {
+    buckets: Vec<UnboundedSender<Sender<()>>>,
+    limiter: DayLimiter,
+}
+
+impl LargeBotQueue {
+    /// Creates a new large bot queue
+    pub async fn new(buckets: usize, http: &dawn_http::Client) -> Self {
+        let mut queues = Vec::with_capacity(buckets);
+        for _ in 0..buckets {
+            let (tx, rx) = unbounded();
+
+            tokio::spawn(async {
+                waiter(rx).await;
+            });
+
+            queues.push(tx)
+        }
+
+        Self {
+            buckets: queues,
+            limiter: DayLimiter::new(http).await.expect(
+                "Getting the first session limits failed, \
+                                                         Is network connection aviable",
+            ),
+        }
+    }
+}
+
+async fn waiter(mut rx: UnboundedReceiver<Sender<()>>) {
+    const DUR: Duration = Duration::from_secs(5);
+    let mut ticker = tokio::time::interval(DUR);
+    while let Some(req) = rx.next().await {
+        ticker.tick().await;
+        if let Err(err) = req.send(()) {
+            warn!(
+                "[LargeBotQueue/waiter] send failed with: {:?}, skipping",
+                err
+            );
+            continue;
+        }
+    }
+}
+
+#[async_trait]
+impl Queue for LargeBotQueue {
+    /// Request to be able to identify with the gateway. This will place this
+    /// request behind all other requests, and the returned future will resolve
+    /// once the request has been completed.
+    async fn request(&self, shard_id: [u64; 2]) {
+        #[allow(clippy::cast_possible_truncation)]
+        let bucket = (shard_id[0] % 16) as usize;
+        let (tx, rx) = oneshot::channel();
+
+        self.limiter.get().await;
+        if let Err(err) = self.buckets[bucket].clone().send(tx).await {
+            warn!("[LargeBotQueue] send failed with: {:?}, skipping", err);
+            return;
+        }
+
+        info!("Waiting for allowance on shard: {}!", shard_id[0]);
+
+        let _ = rx.await;
+    }
+}

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -56,7 +56,8 @@ pub struct ShardProcessor {
 impl ShardProcessor {
     pub async fn new(config: Arc<Config>) -> Result<(Self, WatchReceiver<Arc<Session>>)> {
         debug!("[ShardProcessor {:?}] Queueing", config.shard());
-        config.queue.request().await;
+        let shard_id = config.shard();
+        config.queue.request(shard_id).await;
         debug!("[ShardProcessor {:?}] Finished queue", config.shard());
 
         let properties = IdentifyProperties::new("dawn.rs", "dawn.rs", OS, "", "");
@@ -264,7 +265,8 @@ impl ShardProcessor {
         loop {
             // Await allowance if doing a full reconnect
             if full_reconnect {
-                self.config.queue.request().await;
+                let shard = self.config.shard();
+                self.config.queue.request(shard).await;
             }
 
             let new_stream = match connect::connect(&self.url).await {


### PR DESCRIPTION
This commit changes the queue trait so it can be used to support large
bots. It does that by adding a parameter to request that is the id of
the shard that you are requesting a identify on.

It also adds a new queue that is targeted large bots but can be used
with bot of all sizes if you set the queue size to be 1. This queue
also does bookkeeping so you do not go above the per day limit of
identifies.

Signed-off-by: Valdemar Erk <valdemar@erk.io>